### PR TITLE
Add support for collecting CPU Utilization data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +77,64 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -102,10 +172,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -115,6 +201,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -187,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,17 +313,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "performance-data-assistant"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clap",
+ "ctor",
  "env_logger",
  "lazy_static",
  "log",
+ "procfs",
  "serde",
  "serde_yaml",
  "thiserror",
  "timerfd",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -232,6 +366,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -313,6 +462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +486,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -377,6 +538,12 @@ name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,20 @@ name = "performance-data-assistant"
 version = "0.1.0"
 edition = "2021"
 
+publish = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 name = "performance_data"
 path = "src/lib.rs"
 
-publish = false
+[[bin]]
+name = "performance-data-assistant"
+path = "src/bin/collector.rs"
 
 [dependencies]
+clap = {version = "3.2.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde_yaml = "0.8"
@@ -20,3 +25,5 @@ log = "0.4.0"
 env_logger = "0.8.4"
 lazy_static = "1.4.0"
 timerfd = "1.3.0"
+procfs = "0.12.0"
+ctor = "0.1.22"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 A CLI tool to gather many pieces of performance data in one go.
 
+## Requirements
+* Rust toolchain (v1.61.0+) - https://www.rust-lang.org/tools/install
+
+## Building from source
+```
+cargo build
+cargo test
+cargo run
+```
+
+## Usage
+```
+./performance-data-assistant -h
+```
+
+## Example
+```
+./performance-data-assistant -i 1 -p 10
+```
+* This collects the performance data in 1 second time intervals for 10 seconds.
+
+## Logs
+* env_logger is used to log information about the tool run to stdout.
+* To see it, use `export PDA_LOG_LEVEL=info`.
+* To see more detail, use `export PDA_LOG_LEVEL=debug`.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/src/bin/collector.rs
+++ b/src/bin/collector.rs
@@ -1,0 +1,47 @@
+#[macro_use]
+extern crate log;
+use env_logger::Env;
+
+use clap::Parser;
+use performance_data::PERFORMANCE_DATA;
+use performance_data::{InitParams, PDResult};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Interval (in seconds) at which performance data is to be collected.
+    #[clap(short, long, value_parser, default_value_t = 1)]
+    interval: u64,
+
+    /// Time (in seconds) for which the performance data is to be collected.
+    #[clap(short, long, value_parser, default_value_t = 10)]
+    period: u64,
+}
+
+fn init_logger() {
+    let env = Env::default().filter("PDA_LOG_LEVEL");
+
+    env_logger::init_from_env(env);
+}
+
+fn start_collection_serial() -> PDResult {
+    info!("Collecting data serially...");
+    PERFORMANCE_DATA.lock().unwrap().collect_data_serial()?;
+    Ok(())
+}
+
+fn main() -> PDResult {
+    let args = Args::parse();
+    let mut params = InitParams::new();
+
+    /* Initialize logging system */
+    init_logger();
+
+    params.period = args.period;
+    params.interval = args.interval;
+    PERFORMANCE_DATA.lock().unwrap().set_params(params);
+    PERFORMANCE_DATA.lock().unwrap().init_collectors()?;
+    info!("Starting Performance Data collection:");
+    start_collection_serial()?;
+    Ok(())
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,7 @@
+pub mod cpu_utilization;
+
 use crate::{InitParams, PDResult};
+use cpu_utilization::CpuUtilization;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_yaml::{self};
@@ -47,19 +50,107 @@ impl DataType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub enum Data {
-    None,
+/// Create a Data Enum
+///
+/// Each enum type will have a collect_data implemented for it.
+macro_rules! data {
+    ( $( $x:ident ),* ) => {
+        #[derive(Serialize, Deserialize, Debug)]
+        pub enum Data {
+            $(
+                $x($x),
+            )*
+        }
+
+        impl Data {
+            fn collect_data(&mut self) -> PDResult {
+                match self {
+                    $(
+                        Data::$x(ref mut value) => value.collect_data()?,
+                    )*
+                }
+                Ok(())
+            }
+        }
+    };
 }
 
-impl Data {
-    fn collect_data(&mut self) -> PDResult {
-        match self {
-            Data::None => Ok(()),
-        }
-    }
-}
+data!(CpuUtilization);
 
 pub trait CollectData {
     fn collect_data(&mut self) -> PDResult;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cpu_utilization::CpuUtilization;
+    use super::Data;
+    use super::DataType;
+    use crate::InitParams;
+    use serde::Deserialize;
+    use serde_yaml::{self};
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn test_data_type_init() {
+        let mut param = InitParams::new();
+        let data = CpuUtilization::new();
+        let mut dt = DataType {
+            data: Data::CpuUtilization(data),
+            file_handle: None,
+            file_name: "cpu_utilization".to_string(),
+            full_path: String::new(),
+            dir_name: String::new(),
+        };
+
+        param.dir_name = format!("./performance_data_init_test_{}", param.time_str);
+        let _ret = fs::DirBuilder::new()
+            .recursive(true)
+            .create(param.dir_name.clone())
+            .unwrap();
+
+        dt.init_data_type(param).unwrap();
+
+        assert!(!dt.file_handle.is_none());
+        fs::remove_file(dt.full_path).unwrap();
+        fs::remove_dir_all(dt.dir_name).unwrap();
+    }
+
+    #[test]
+    fn test_print() {
+        let mut param = InitParams::new();
+        let data = CpuUtilization::new();
+        let mut dt = DataType {
+            data: Data::CpuUtilization(data),
+            file_handle: None,
+            file_name: "cpu_utilization".to_string(),
+            full_path: String::new(),
+            dir_name: String::new(),
+        };
+
+        param.dir_name = format!("./performance_data_print_test_{}", param.time_str);
+        let _ret = fs::DirBuilder::new()
+            .recursive(true)
+            .create(param.dir_name.clone())
+            .unwrap();
+
+        dt.init_data_type(param).unwrap();
+
+        assert!(Path::new(&dt.full_path).exists());
+        assert!(dt.print_to_file().unwrap() == ());
+
+        for document in serde_yaml::Deserializer::from_reader(dt.file_handle.unwrap()) {
+            let v = Data::deserialize(document).expect("File read error");
+            match v {
+                Data::CpuUtilization(ref value) => {
+                    assert!(value.total.cpu == 0);
+                    assert!(value.per_cpu.is_empty());
+                }
+                _ => assert!(true),
+            }
+        }
+        fs::remove_file(dt.full_path).unwrap();
+        fs::remove_dir_all(dt.dir_name).unwrap();
+    }
 }

--- a/src/data/cpu_utilization.rs
+++ b/src/data/cpu_utilization.rs
@@ -1,0 +1,162 @@
+extern crate ctor;
+
+use crate::data::{CollectData, Data, DataType};
+use crate::PDResult;
+use crate::PERFORMANCE_DATA;
+use chrono::prelude::*;
+use ctor::ctor;
+use log::debug;
+use procfs::{CpuTime, KernelStats};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CpuData {
+    pub time: DateTime<Utc>,
+    pub cpu: i64,
+    pub user: u64,
+    pub nice: u64,
+    pub system: u64,
+    pub irq: u64,
+    pub softirq: u64,
+    pub idle: u64,
+    pub iowait: u64,
+    pub steal: u64,
+}
+
+impl CpuData {
+    fn new() -> Self {
+        CpuData {
+            time: Utc::now(),
+            cpu: 0,
+            user: 0,
+            nice: 0,
+            system: 0,
+            irq: 0,
+            softirq: 0,
+            idle: 0,
+            iowait: 0,
+            steal: 0,
+        }
+    }
+
+    fn set_data(&mut self, cpu: i64, time: DateTime<Utc>, cpu_time: &CpuTime) {
+        self.cpu = cpu;
+        self.time = time;
+        self.user = cpu_time.user;
+        self.nice = cpu_time.nice;
+        self.system = cpu_time.system;
+        self.irq = cpu_time.irq.unwrap_or_default();
+        self.softirq = cpu_time.softirq.unwrap_or_default();
+        self.idle = cpu_time.idle;
+        self.iowait = cpu_time.iowait.unwrap_or_default();
+        self.steal = cpu_time.steal.unwrap_or_default();
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CpuUtilization {
+    pub total: CpuData,
+    pub per_cpu: Vec<CpuData>,
+}
+
+impl CpuUtilization {
+    pub fn new() -> Self {
+        CpuUtilization {
+            total: CpuData::new(),
+            per_cpu: Vec::<CpuData>::new(),
+        }
+    }
+
+    fn set_total(&mut self, cpu: i64, time: DateTime<Utc>, total: CpuTime) {
+        self.total.set_data(cpu, time, &total);
+    }
+
+    fn add_per_cpu_data(&mut self, cpu_data: CpuData) {
+        self.per_cpu.push(cpu_data);
+    }
+
+    fn clear_per_cpu_data(&mut self) {
+        self.per_cpu.clear();
+    }
+}
+
+impl CollectData for CpuUtilization {
+    fn collect_data(&mut self) -> PDResult {
+        let stat = KernelStats::new().unwrap();
+        let time_now = Utc::now();
+        self.clear_per_cpu_data();
+
+        /* Get total numbers */
+        self.set_total(-1, time_now, stat.total);
+
+        debug!("Total CPU Utilization: {:#?}", self.total);
+        /* Get per_cpu numbers */
+        for (i, cpu) in stat.cpu_time.iter().enumerate() {
+            let mut current_cpu_data = CpuData::new();
+
+            /* Set this CPU's data */
+            current_cpu_data.set_data(i as i64, time_now, cpu);
+
+            /* Push to Vec of per_cpu data */
+            self.add_per_cpu_data(current_cpu_data);
+        }
+        debug!("Per CPU Utilization: {:#?}", self.per_cpu);
+        Ok(())
+    }
+}
+
+impl Default for CpuUtilization {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[ctor]
+fn init_cpu_utilization() {
+    let cpu_utilization = CpuUtilization::new();
+
+    let dt = DataType {
+        data: Data::CpuUtilization(cpu_utilization),
+        file_handle: None,
+        file_name: "cpu_utilization".to_string(),
+        dir_name: String::new(),
+        full_path: String::new(),
+    };
+    PERFORMANCE_DATA
+        .lock()
+        .unwrap()
+        .add_datatype("CPU Utilization".to_string(), dt);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CpuUtilization;
+    use crate::data::{CollectData, Data, DataType};
+
+    #[test]
+    fn test_init() {
+        let cpu_utilization = DataType {
+            data: Data::CpuUtilization(CpuUtilization::new()),
+            file_handle: None,
+            file_name: "cpu_utilization".to_string(),
+            full_path: String::new(),
+            dir_name: String::new(),
+        };
+
+        match cpu_utilization.data {
+            Data::CpuUtilization(_) => assert!(true),
+            _ => assert!(false, "CPU Utilization enum type error"),
+        }
+        assert!(cpu_utilization.file_handle.is_none());
+        assert!(cpu_utilization.file_name == "cpu_utilization");
+    }
+
+    #[test]
+    fn test_collect_data() {
+        let mut cpu_utilization = CpuUtilization::new();
+
+        assert!(cpu_utilization.collect_data().unwrap() == ());
+        assert!(cpu_utilization.total.cpu == -1);
+        assert!(!cpu_utilization.per_cpu.is_empty());
+    }
+}


### PR DESCRIPTION
Use procfs and collect CPU utilization data (both aggregate and per cpu)
from /proc/stat.

The data collected is stored in a YAML file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
