### PR TITLE
Use TimeEnum for storing time data

### DIFF
--- a/src/data/diskstats.rs
+++ b/src/data/diskstats.rs
@@ -1,6 +1,6 @@
 extern crate ctor;
 
-use crate::data::{CollectData, Data, DataType};
+use crate::data::{CollectData, Data, DataType, TimeEnum};
 use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
@@ -85,20 +85,24 @@ pub struct DiskStat {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Diskstats {
-    pub time: DateTime<Utc>,
+    pub time: TimeEnum,
     pub disk_stats: Vec<DiskStat>,
 }
 
 impl Diskstats {
     fn new() -> Self {
         Diskstats {
-            time: Utc::now(),
+            time: TimeEnum::DateTime(Utc::now()),
             disk_stats: Vec::new(),
         }
     }
 
     fn set_data(&mut self, data: Vec<DiskStat>) {
         self.disk_stats = data;
+    }
+
+    fn set_time(&mut self, time: TimeEnum) {
+        self.time = time;
     }
 }
 
@@ -132,6 +136,7 @@ impl CollectData for Diskstats {
 
         debug!("Diskstats:\n{:#?}", self);
         self.set_data(data);
+        self.set_time(TimeEnum::DateTime(Utc::now()));
         Ok(())
     }
 }

--- a/src/data/vmstat.rs
+++ b/src/data/vmstat.rs
@@ -1,6 +1,6 @@
 extern crate ctor;
 
-use crate::data::{CollectData, Data, DataType};
+use crate::data::{CollectData, Data, DataType, TimeEnum};
 use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
@@ -14,19 +14,19 @@ pub static VMSTAT_FILE_NAME: &str = "vmstat";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Vmstat {
-    pub time: DateTime<Utc>,
+    pub time: TimeEnum,
     pub vmstat_data: HashMap<String, i64>,
 }
 
 impl Vmstat {
     fn new() -> Self {
         Vmstat {
-            time: Utc::now(),
+            time: TimeEnum::DateTime(Utc::now()),
             vmstat_data: HashMap::new(),
         }
     }
 
-    fn set_time(&mut self, time: DateTime<Utc>) {
+    fn set_time(&mut self, time: TimeEnum) {
         self.time = time;
     }
 
@@ -40,7 +40,7 @@ impl CollectData for Vmstat {
         let time_now = Utc::now();
         let vmstat_data = vmstat().unwrap();
 
-        self.set_time(time_now);
+        self.set_time(TimeEnum::DateTime(time_now));
         self.set_data(vmstat_data);
         debug!("Vmstat data: {:#?}", self);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@ pub enum PDError {
         source: std::io::Error,
     },
 
+    #[error("Time Error")]
+    TimeError,
+
     #[error(transparent)]
     YAMLError(#[from] serde_yaml::Error),
 }


### PR DESCRIPTION
Use TimeEnum for time instead of DateTime<Utc>. This will allow us to reuse the field to hold absolute time difference.

This is in preparation for adding support for the visualizer, where the data returned will be a diff of values at time t and time t+1. The time difference will be stored in the same time field set with the TimeEnum::TimeDiff type.

Also, fix Diskstats to have the right timestamp for each data collected. It was set to use the starting time always.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
