### PR TITLE
Use Anyhow for error propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +413,7 @@ checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 name = "performance-data-assistant"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "performance_data"
 path = "src/lib.rs"
 
 [[bin]]
-name = "performance-data-assistant"
+name = "performance-data-collector"
 path = "src/bin/collector.rs"
 
 [dependencies]
@@ -28,3 +28,4 @@ timerfd = "1.3.0"
 procfs = "0.12.0"
 ctor = "0.1.22"
 sysinfo = "0.26.2"
+anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ cargo run
 
 ## Usage
 ```
-./performance-data-assistant -h
+./performance-data-collector -h
 ```
 
 ## Example
 ```
-./performance-data-assistant -i 1 -p 10
+./performance-data-collector -i 1 -p 10
 ```
 * This collects the performance data in 1 second time intervals for 10 seconds.
 

--- a/src/bin/collector.rs
+++ b/src/bin/collector.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate log;
-use env_logger::Env;
 
+use anyhow::Result;
+use env_logger::Env;
 use clap::Parser;
-use performance_data::PERFORMANCE_DATA;
-use performance_data::{InitParams, PDResult};
+use performance_data::{InitParams, PERFORMANCE_DATA};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -24,19 +24,19 @@ fn init_logger() {
     env_logger::init_from_env(env);
 }
 
-fn start_collection_serial() -> PDResult {
+fn start_collection_serial() -> Result<()> {
     info!("Collecting data serially...");
     PERFORMANCE_DATA.lock().unwrap().collect_data_serial()?;
     Ok(())
 }
 
-fn collect_static_data() -> PDResult {
+fn collect_static_data() -> Result<()> {
     info!("Collecting data only once...");
     PERFORMANCE_DATA.lock().unwrap().collect_static_data()?;
     Ok(())
 }
 
-fn main() -> PDResult {
+fn main() -> Result<()> {
     let args = Args::parse();
     let mut params = InitParams::new();
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,7 +4,8 @@ pub mod diskstats;
 pub mod systeminfo;
 pub mod kernel_config;
 
-use crate::{InitParams, PDResult};
+use anyhow::Result;
+use crate::InitParams;
 use chrono::prelude::*;
 use cpu_utilization::CpuUtilization;
 use log::debug;
@@ -42,7 +43,7 @@ impl DataType {
         self.file_handle = handle;
     }
 
-    pub fn init_data_type(&mut self, param: InitParams) -> PDResult {
+    pub fn init_data_type(&mut self, param: InitParams) -> Result<()> {
         debug!("Initializing data type...");
         let name = format!("{}_{}.yaml", self.file_name, param.time_str);
         let full_path = format!("{}/{}", param.dir_name, name);
@@ -63,13 +64,13 @@ impl DataType {
         Ok(())
     }
 
-    pub fn collect_data(&mut self) -> PDResult {
+    pub fn collect_data(&mut self) -> Result<()> {
         debug!("Collecting Data...");
         self.data.collect_data()?;
         Ok(())
     }
 
-    pub fn print_to_file(&mut self) -> PDResult {
+    pub fn print_to_file(&mut self) -> Result<()> {
         debug!("Printing to YAML file...");
         let file_handle = self.file_handle.as_ref().unwrap();
         serde_yaml::to_writer(file_handle.try_clone()?, &self.data)?;
@@ -116,7 +117,7 @@ macro_rules! data {
         }
 
         impl Data {
-            fn collect_data(&mut self) -> PDResult {
+            fn collect_data(&mut self) -> Result<()> {
                 match self {
                     $(
                         Data::$x(ref mut value) => value.collect_data()?,
@@ -131,7 +132,7 @@ macro_rules! data {
 data!(CpuUtilization, Vmstat, Diskstats, SystemInfo, KernelConfig);
 
 pub trait CollectData {
-    fn collect_data(&mut self) -> PDResult;
+    fn collect_data(&mut self) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/src/data/cpu_utilization.rs
+++ b/src/data/cpu_utilization.rs
@@ -1,7 +1,7 @@
 extern crate ctor;
 
+use anyhow::Result;
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
 use ctor::ctor;
@@ -90,7 +90,7 @@ impl CpuUtilization {
 }
 
 impl CollectData for CpuUtilization {
-    fn collect_data(&mut self) -> PDResult {
+    fn collect_data(&mut self) -> Result<()> {
         let stat = KernelStats::new().unwrap();
         let time_now = Utc::now();
         self.clear_per_cpu_data();

--- a/src/data/diskstats.rs
+++ b/src/data/diskstats.rs
@@ -1,7 +1,7 @@
 extern crate ctor;
 
+use anyhow::Result;
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
 use ctor::ctor;
@@ -107,7 +107,7 @@ impl Diskstats {
 }
 
 impl CollectData for Diskstats {
-    fn collect_data(&mut self) -> PDResult {
+    fn collect_data(&mut self) -> Result<()> {
         let stats = diskstats().unwrap();
         let mut data = Vec::<DiskStat>::new();
         for disk in stats {

--- a/src/data/kernel_config.rs
+++ b/src/data/kernel_config.rs
@@ -1,7 +1,7 @@
 extern crate ctor;
 
+use anyhow::Result;
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
 use ctor::ctor;
@@ -37,7 +37,7 @@ impl KernelConfig {
 }
 
 impl CollectData for KernelConfig {
-    fn collect_data(&mut self) -> PDResult {
+    fn collect_data(&mut self) -> Result<()> {
         let time_now = Utc::now();
         let kernel_config_data = kernel_config().unwrap();
         let mut kernel_data_processed: HashMap<String, String> = HashMap::new();

--- a/src/data/systeminfo.rs
+++ b/src/data/systeminfo.rs
@@ -1,8 +1,8 @@
 extern crate ctor;
 
+use anyhow::Result;
 use sysinfo::{System, SystemExt};
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
 use ctor::ctor;
@@ -55,7 +55,7 @@ impl SystemInfo {
 }
 
 impl CollectData for SystemInfo {
-    fn collect_data(&mut self) -> PDResult {
+    fn collect_data(&mut self) -> Result<()> {
         let mut sys = System::new_all();
         sys.refresh_all();
 

--- a/src/data/vmstat.rs
+++ b/src/data/vmstat.rs
@@ -1,7 +1,7 @@
 extern crate ctor;
 
+use anyhow::Result;
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::PDResult;
 use crate::PERFORMANCE_DATA;
 use chrono::prelude::*;
 use ctor::ctor;
@@ -36,7 +36,7 @@ impl Vmstat {
 }
 
 impl CollectData for Vmstat {
-    fn collect_data(&mut self) -> PDResult {
+    fn collect_data(&mut self) -> Result<()> {
         let time_now = Utc::now();
         let vmstat_data = vmstat().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 
 pub mod data;
+use anyhow::Result;
 use chrono::prelude::*;
 use log::{error, info};
 use std::collections::HashMap;
@@ -11,23 +12,9 @@ use std::time;
 use thiserror::Error;
 use timerfd::{SetTimeFlags, TimerFd, TimerState};
 
-#[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum PDError {
-    #[error("File Error")]
-    FileError {
-        #[from]
-        source: std::io::Error,
-    },
-
-    #[error("Time Error")]
-    TimeError,
-
-    #[error(transparent)]
-    YAMLError(#[from] serde_yaml::Error),
 }
-
-pub type PDResult = Result<(), PDError>;
 
 lazy_static! {
     pub static ref PERFORMANCE_DATA: Mutex<PerformanceData> = Mutex::new(PerformanceData::new());
@@ -58,7 +45,7 @@ impl PerformanceData {
         self.collectors.insert(name, dt);
     }
 
-    pub fn init_collectors(&mut self) -> PDResult {
+    pub fn init_collectors(&mut self) -> Result<()> {
         let _ret = fs::create_dir_all(self.init_params.dir_name.clone()).unwrap();
 
         for (_name, datatype) in self.collectors.iter_mut() {
@@ -67,7 +54,7 @@ impl PerformanceData {
         Ok(())
     }
 
-    pub fn collect_static_data(&mut self) -> PDResult {
+    pub fn collect_static_data(&mut self) -> Result<()> {
         for (_name, datatype) in self.collectors.iter_mut() {
             if !datatype.is_static {
                 continue;
@@ -79,7 +66,7 @@ impl PerformanceData {
         Ok(())
     }
 
-    pub fn collect_data_serial(&mut self) -> PDResult {
+    pub fn collect_data_serial(&mut self) -> Result<()> {
         let start = time::Instant::now();
         let mut current = time::Instant::now();
         let end = current + time::Duration::from_secs(self.init_params.period);


### PR DESCRIPTION
Also, change the binary name to performance-data-collector from performance-data-assistant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
