### PR TITLE
Add support for visualizing Kernel Config data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,9 +1506,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libgit2-sys"
@@ -1717,6 +1723,7 @@ dependencies = [
  "lazy_static",
  "log",
  "procfs",
+ "rustix 0.35.11",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2035,10 +2042,24 @@ checksum = "2079c267b8394eb529872c3cf92e181c378b41fea36e68130357b52493701d2e"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.6.1",
  "libc",
  "linux-raw-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.3",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2552,7 +2573,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f85a7c965b8e7136952f59f2a359694c78f105b2d2ff99cf6c2c404bf7e33f"
 dependencies = [
- "rustix",
+ "rustix 0.34.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/bin/visualizer.rs"
 clap = {version = "3.2.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
+rustix = { version = "0.35.6", features = ["process"] }
 async-std = { version = "1.8.0", features = ["attributes"] }
 serde_yaml = "0.8"
 thiserror = "1.0"

--- a/src/bin/html_files/index.html
+++ b/src/bin/html_files/index.html
@@ -7,8 +7,9 @@
 	<body>
 		<h2>Performance Data Assistant</h2>
 		<div class="tab">
-			<button class="tablinks" name="cpu_utilization">CPU Utilization</button>
+			<button class="tablinks" name="cpu_utilization" id="default">CPU Utilization</button>
 			<button class="tablinks" name="vmstat">VM Stat</button>
+			<button class="tablinks" name="kernel_config">Kernel Config</button>
 		</div>
 		<div id="cpu_utilization" class="tabcontent">
 			<div id="cpu-util-runs"></div>
@@ -16,8 +17,17 @@
 		<div id="vmstat" class="tabcontent">
 			<div id="vmstat-runs"></div>
 		</div>
+		<div id="kernel_config" class="tabcontent">
+			<div>
+				<h3>Diff:</h3>
+				<input type="radio" class="kernel-button" id="kernel_diff_yes" name="kernelDiff">Yes</button>
+				<input type="radio" class="kernel-button" id="kernel_diff_no" name="kernelDiff">No</button>
+			</div>
+			<div id="kernel-config-runs"></div>
+		</div>
 		<script type="module" src="/html_files/index.js"></script>
 		<script type="module" src="/html_files/cpu_utilization.js"></script>
 		<script type="module" src="/html_files/vmstat.js"></script>
+		<script type="module" src="/html_files/kernel_config.js"></script>
 	</body>
 </html>

--- a/src/bin/html_files/index.ts
+++ b/src/bin/html_files/index.ts
@@ -1,5 +1,6 @@
 import { cpuUtilization } from './cpu_utilization.js';
 import { vmStat } from './vmstat.js';
+import { kernelConfig } from './kernel_config.js';
 export { clearElements, addElemToNode, openData };
 
 function openData(evt: Event, elem: HTMLButtonElement) {
@@ -20,6 +21,9 @@ function openData(evt: Event, elem: HTMLButtonElement) {
 	}
 	if (tabName == "vmstat") {
 		vmStat();
+	}
+	if (tabName == "kernel_config") {
+		kernelConfig(false);
 	}
 }
 // Collapse functionality
@@ -43,6 +47,16 @@ for (var i=0; i < elems.length; i++) {
 		openData(evt, this)
 	}, false);
 }
+var elems = document.getElementsByClassName('kernel-button');
+for (var i=0; i < elems.length; i++) {
+	elems[i].addEventListener("click",function(evn: Event) {
+		if (this.id == "kernel_diff_yes"){
+			kernelConfig(true);
+		} else {
+			kernelConfig(false);
+		}
+	} )
+}
 
 function clearElements(id: string) {
 	let node: HTMLElement = document.getElementById(id);
@@ -55,3 +69,6 @@ function addElemToNode(node_id: string, elem: HTMLElement) {
 	let node: HTMLElement = document.getElementById(node_id);
 	node.appendChild(elem);
 }
+
+// Show landing page
+document.getElementById("default").click();

--- a/src/bin/html_files/kernel_config.ts
+++ b/src/bin/html_files/kernel_config.ts
@@ -1,0 +1,132 @@
+import { clearElements, addElemToNode } from "./index.js";
+export { kernelConfig };
+
+var diff_data: Array<Entry> = [];
+var common_data: Array<Entry> = [];
+class Entry {
+    run: string;
+    title: string;
+    value: string;
+}
+
+function addEntry(entry: Entry) {
+    var add = true;
+    for (let i = 0; i < common_data.length; i++) {
+        if (common_data[i].title == entry.title &&
+            common_data[i].value == entry.value) {
+                return;
+            }
+    }
+    for (let i = 0; i < diff_data.length; i++) {
+        if (diff_data[i].title == entry.title &&
+            diff_data[i].value == entry.value) {
+                common_data.push(entry);
+                diff_data.splice(i, 1);
+                return;
+            }
+    }
+    diff_data.push(entry);
+}
+
+function containsEntry(title: string) {
+    var found = false;
+    diff_data.forEach(function (value, index, arr) {
+        if (value.title == title) {
+            found = true;
+        }
+    })
+    return found;
+}
+
+function createEntries(container_id, values, level, run, diff) {
+    values?.forEach(function(value, index, arr) {
+        for (var prop in value) {
+            if ('value' in value[prop]) {
+                if (diff && !containsEntry(value[prop].name)) {
+                    continue;
+                }
+                var dt = document.createElement('dt');
+                dt.style.textIndent = `${level * 5}%`;
+                dt.style.fontWeight = "normal";
+                dt.innerHTML = `${value[prop].name} = ${value[prop].value}`;
+                addElemToNode(container_id, dt);
+                if (!diff) {
+                    var entry = new Entry();
+                    entry.run = run;
+                    entry.title = value[prop].name;
+                    entry.value = value[prop].value;
+                    addEntry(entry);
+                }
+            } else {
+                var dl = document.createElement('dl');
+                dl.style.textIndent = `${level * 5}%`;
+                dl.innerHTML = value[prop].name;
+                dl.style.fontWeight = "bold";
+                dl.id = `${run}-${value[prop].name}`;
+                addElemToNode(container_id, dl);
+                createEntries(dl.id, value[prop].entries, level + 1, run, diff);
+            }
+        }
+    });
+}
+
+function getKernelConfig(run, container_id, diff) {
+    const http = new XMLHttpRequest();
+    http.onload = function () {
+        var data = JSON.parse(http.response);
+        var dl = document.createElement('dl');
+        dl.id = `${run}-kernel-config`;
+        dl.style.float = "none";
+        var dl_id = dl.id;
+        addElemToNode(container_id, dl);
+        data.forEach(function (value, index, arr) {
+            var dt = document.createElement('dl');
+            dt.id = `${run}-${value.name}`;
+            dt.style.fontWeight = "bold";
+            dt.innerHTML = value.name;
+            addElemToNode(dl_id, dt);
+            createEntries(dt.id, value.entries, 1, run, diff);
+        });
+    }
+    http.open("GET", `visualize/kernel_config?run=${run}&get=values`);
+    http.send();
+}
+
+function kernelConfig(diff: boolean) {
+    if (!diff) {
+        diff_data = [];
+    }
+    const http = new XMLHttpRequest();
+    http.onload = function () {
+        var data = JSON.parse(http.response);
+        var float_style = "none";
+        if (data.length > 1) {
+            float_style = "left";
+        }
+        var run_width = 100 / data.length;
+        clearElements('kernel-config-runs');
+        data.forEach(function (value, index, arr) {
+            // Run div
+            var run_div = document.createElement('div');
+            run_div.id = `${value}-kernel-config`;
+            run_div.style.float = float_style;
+            run_div.style.width = `${run_width}%`;
+            addElemToNode('kernel-config-runs', run_div);
+            var run_node_id = run_div.id;
+
+            // Run name
+            var h3_run_name = document.createElement('h3');
+            h3_run_name.innerHTML = `${value}`;
+            h3_run_name.style.textAlign = "center";
+            addElemToNode(run_node_id, h3_run_name);
+
+            //Show aggregate data
+            var agg_elem = document.createElement('div');
+            agg_elem.id = `${value}-kernel-config-div`;
+            addElemToNode(run_node_id, agg_elem);
+            getKernelConfig(value, agg_elem.id, diff);
+        })
+    }
+    http.open("GET", 'visualize/get?get=entries');
+    http.send();
+}

--- a/src/data/kernel_config.rs
+++ b/src/data/kernel_config.rs
@@ -2,29 +2,63 @@ extern crate ctor;
 
 use anyhow::Result;
 use crate::data::{CollectData, Data, DataType, TimeEnum};
-use crate::{PERFORMANCE_DATA, VISUALIZATION_DATA};
+use crate::{PERFORMANCE_DATA, PDError, VISUALIZATION_DATA};
 use crate::visualizer::{DataVisualizer, GetData};
 use chrono::prelude::*;
 use ctor::ctor;
 use log::debug;
-use procfs::{ConfigSetting, kernel_config};
-use std::collections::HashMap;
 use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
+use std::fs::OpenOptions;
 
 pub static KERNEL_CONFIG_FILE_NAME: &str = "kernel_config";
+const PROC_CONFIG_GZ: &str = "/proc/config.gz";
+const BOOT_CONFIG: &str = "/boot/config";
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Entry {
+    ConfigEntry(KernelConfigEntry),
+    ConfigGroup(KernelConfigEntryGroup),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KernelConfigEntry {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KernelConfigEntryGroup {
+    pub name: String,
+    pub entries: Vec<Entry>,
+}
+
+impl KernelConfigEntryGroup {
+    fn new() -> Self {
+        KernelConfigEntryGroup {
+            name: String::new(),
+            entries: Vec::new(),
+        }
+    }
+
+    fn add_entry(&mut self, entry: Entry) {
+        self.entries.push(entry);
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KernelConfig {
     pub time: TimeEnum,
-    pub kernel_config_data: HashMap<String, String>,
+    pub kernel_config_data: Vec<KernelConfigEntryGroup>,
 }
 
 impl KernelConfig {
     fn new() -> Self {
         KernelConfig {
             time: TimeEnum::DateTime(Utc::now()),
-            kernel_config_data: HashMap::new(),
+            kernel_config_data: Vec::new(),
         }
     }
 
@@ -32,29 +66,127 @@ impl KernelConfig {
         self.time = time;
     }
 
-    fn set_data(&mut self, data: HashMap<String, String>) {
+    fn set_data(&mut self, data: Vec<KernelConfigEntryGroup>) {
         self.kernel_config_data = data;
     }
+}
+
+fn get_kernel_config_data() -> Result<Box<dyn BufRead>> {
+    /* This is the same as procfs crate. We need access to the commented out CONFIGs and
+     * headings in the Config file.
+     */
+    let reader: Box<dyn BufRead> = if Path::new(PROC_CONFIG_GZ).exists() && cfg!(features = "flate2") {
+        #[cfg(feature = "flate2")]
+        {
+            let file = OpenOptions::new()
+                .read(true)
+                .open(PROC_CONFIG_GZ);
+            let decoder = flate2::read::GzDecoder::new(file);
+            Box::new(BufReader::new(decoder))
+        }
+        #[cfg(not(feature = "flate2"))]
+        {
+            unreachable!("flate2 feature not enabled")
+        }
+    } else {
+        let kernel = rustix::process::uname();
+        let filename = format!("{}-{}", BOOT_CONFIG, kernel.release().to_string_lossy());
+        let file = OpenOptions::new()
+            .read(true)
+            .open(filename);
+        match file {
+            Ok(file) => Box::new(BufReader::new(file)),
+            Err(e) => match e.kind() {
+                io::ErrorKind::NotFound => {
+                    let backup_config_file = OpenOptions::new()
+                        .read(true)
+                        .open(BOOT_CONFIG)
+                        .expect("Could not open file");
+                    Box::new(BufReader::new(backup_config_file))
+                }
+                _ => return Err(e.into()),
+            },
+        }
+    };
+    Ok(reader)
 }
 
 impl CollectData for KernelConfig {
     fn collect_data(&mut self) -> Result<()> {
         let time_now = Utc::now();
-        let kernel_config_data = kernel_config().unwrap();
-        let mut kernel_data_processed: HashMap<String, String> = HashMap::new();
+        let mut kernel_data_processed: Vec<KernelConfigEntryGroup> = Vec::new();
+        let mut comments = Vec::new();
 
-        for (key, key_value) in &kernel_config_data {
-            let output;
+        /* Get kernel config data from file */
+        let kernel_data = get_kernel_config_data()?;
 
-            match key_value {
-                ConfigSetting::Yes => output = "y",
-                ConfigSetting::Module => output = "m",
-                ConfigSetting::Value(s) => output = s,
+        let mut first_group = KernelConfigEntryGroup::new();
+        first_group.name = "".to_string();
+        kernel_data_processed.push(first_group);
+
+        for line in kernel_data.lines() {
+            let line = line?;
+            if line.starts_with('#') &&
+                !line.contains("is not set") &&
+                !line.contains("NOTE") &&
+                !line.contains("also be needed") &&
+                !line.contains("end of") {
+                comments.push(line);
+                continue;
+            } else {
+                if comments.len() == 3 {
+                    let mut group = KernelConfigEntryGroup::new();
+                    group.name = comments[1].clone()[2..].to_string();
+                    kernel_data_processed.push(group.clone());
+                }
+                comments.clear();
             }
-
-            kernel_data_processed.insert(key.to_string(), output.parse().unwrap());
+            if line.contains('=') {
+                let mut s = line.splitn(2, '=');
+                let name = s.next().ok_or(PDError::CollectorLineNameError)?.to_owned();
+                let value = s.next().ok_or(PDError::CollectorLineValueError)?;
+                let entry = KernelConfigEntry {
+                    name: name.clone(),
+                    value: value.to_string()
+                };
+                kernel_data_processed.last_mut().unwrap().add_entry(Entry::ConfigEntry(entry));
+                comments.clear();
+            }
+            if line.contains("is not set") {
+                let mut s = line.splitn(3, ' ');
+                s.next();
+                let name = s.next().ok_or(PDError::CollectorLineNameError)?.to_owned();
+                let value = "not set";
+                let entry = KernelConfigEntry {
+                    name: name.clone(),
+                    value: value.to_string()
+                };
+                kernel_data_processed.last_mut().unwrap().add_entry(Entry::ConfigEntry(entry));
+                comments.clear();
+            }
+            if line.contains("end of") {
+                let s = line.splitn(4, ' ');
+                let name = s.last().ok_or(PDError::CollectorLineNameError)?.to_owned();
+                if name == kernel_data_processed.last_mut().unwrap().name {
+                    continue;
+                }
+                let mut group_to_add_index = 0;
+                let mut start_appending: bool = false;
+                for (i, group) in kernel_data_processed.clone().iter().enumerate() {
+                    if group.name == name {
+                        group_to_add_index = i;
+                        start_appending = true;
+                        continue;
+                    }
+                    if start_appending {
+                        kernel_data_processed[group_to_add_index].add_entry(Entry::ConfigGroup(group.clone()));
+                    }
+                }
+                if start_appending {
+                    kernel_data_processed = kernel_data_processed[..group_to_add_index+1].to_vec();
+                }
+            }
         }
-
         self.set_time(TimeEnum::DateTime(time_now));
         self.set_data(kernel_data_processed);
         debug!("KernelConfig data: {:#?}", self);
@@ -62,7 +194,31 @@ impl CollectData for KernelConfig {
     }
 }
 
-impl GetData for KernelConfig {}
+fn get_kernel_config(value: KernelConfig) -> Result<String> {
+    Ok(serde_json::to_string(&value.kernel_config_data)?)
+}
+
+impl GetData for KernelConfig {
+    fn get_data(&mut self, buffer: Vec<Data>, query: String) -> Result<String> {
+        let mut values = Vec::new();
+        for data in buffer {
+            match data {
+                Data::KernelConfig(ref value) => values.push(value.clone()),
+                _ => panic!("Invalid Data type in file"),
+            }
+        }
+        let param: Vec<(String, String)> = serde_urlencoded::from_str(&query).unwrap();
+        if param.len() < 2 {
+            panic!("Not enough arguments");
+        }
+        let (_, req_str) = &param[1];
+
+        match req_str.as_str() {
+            "values" => return get_kernel_config(values[0].clone()),
+            _ => panic!("Unsupported API"),
+        }
+    }
+}
 
 #[ctor]
 fn init_kernel_config() {
@@ -73,11 +229,12 @@ fn init_kernel_config() {
         file_name.clone(),
         true
     );
+    let js_file_name = file_name.clone() + &".js".to_string();
     let dv = DataVisualizer::new(
         Data::KernelConfig(kernel_config),
         file_name.clone(),
-        String::new(),
-        String::new(),
+        js_file_name,
+        include_str!("../bin/html_files/js/kernel_config.js").to_string(),
         file_name.clone(),
     );
 
@@ -94,8 +251,9 @@ fn init_kernel_config() {
 
 #[cfg(test)]
 mod tests {
-    use super::KernelConfig;
-    use crate::data::CollectData;
+    use super::{KernelConfig, KernelConfigEntryGroup};
+    use crate::data::{CollectData, Data};
+    use crate::visualizer::GetData;
 
     #[test]
     fn test_collect_data() {
@@ -103,5 +261,17 @@ mod tests {
 
         assert!(kernel_config.collect_data().unwrap() == ());
         assert!(kernel_config.kernel_config_data.len() != 0);
+    }
+
+    #[test]
+    fn test_get_values() {
+        let mut buffer: Vec<Data> = Vec::<Data>::new();
+        let mut kernel_config = KernelConfig::new();
+
+        kernel_config.collect_data().unwrap();
+        buffer.push(Data::KernelConfig(kernel_config));
+        let json = KernelConfig::new().get_data(buffer, "run=test&get=values".to_string()).unwrap();
+        let values: Vec<KernelConfigEntryGroup> = serde_json::from_str(&json).unwrap();
+        assert!(values.len() > 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,12 @@ pub enum PDError {
 
     #[error("Error getting Vmstat value for {}", .0)]
     VisualizerVmstatValueGetError(String),
+
+    #[error("Error getting Line Name Error")]
+    CollectorLineNameError,
+
+    #[error("Error getting Line Value Error")]
+    CollectorLineValueError,
 }
 
 lazy_static! {


### PR DESCRIPTION
Implement the logic to pull data from the Kernel Config files directly. This is the same as the implementation in the procfs crate. We need access to the CONFIGs that are commented out as well as the headers. Additionally, kernel_config() returns a HashMap which mixes up the order of the values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
