### PR TITLE
Tar output files before uploading it as part of releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,17 @@ jobs:
     needs:
       - Build
     steps:
+      - name: Tar X64 artifacts # Below workaround will allow files to be extracted to a directory e.g. pda-v0.1-x86_64/
+        if: ${{ matrix.architecture == 'X64' }}
+        run: sudo mkdir -p pda-${{ github.ref }}-x86_64 && sudo cp ./target/x86_64-unknown-linux-musl/release/performance-data-collector ./target/x86_64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref }}-x86_64 && sudo tar -cvzf pda-${{ github.ref }}-x86_64.tar.gz pda-${{ github.ref }}-x86_64/ && sudo rm -rf pda-${{ github.ref }}-x86_64
+      - name: Tar ARM64 artifacts
+        if: ${{ matrix.architecture == 'ARM64' }}
+        run: sudo mkdir -p pda-${{ github.ref }}-aarch64 && sudo cp ./target/aarch64-unknown-linux-musl/release/performance-data-collector ./target/aarch64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref }}-aarch64 && sudo tar -cvzf pda-${{ github.ref }}-aarch64.tar.gz pda-${{ github.ref }}-aarch64/ && sudo rm -rf pda-${{ github.ref }}-aarch64
       - name: Upload X64 artifacts.
         if: ${{ matrix.architecture == 'X64' }}
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "./target/x86_64-unknown-linux-musl/release/performance-data-collector,./target/x86_64-unknown-linux-musl/release/performance-data-visualizer"
+          artifacts: "./pda-${{ github.ref }}-x86_64.tar.gz"
           replacesArtifacts: false
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
@@ -31,7 +37,7 @@ jobs:
         if: ${{ matrix.architecture == 'ARM64' }}
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "./target/aarch64-unknown-linux-musl/release/performance-data-collector,./target/aarch64-unknown-linux-musl/release/performance-data-visualizer"
+          artifacts: "./pda-${{ github.ref }}-aarch64.tar.gz"
           replacesArtifacts: false
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true


### PR DESCRIPTION
* A temp dir needed to be created first so when files were extracted they will extract to right folder.
