### PR TITLE
Change to use github.ref_name for naming tar file instead of github.ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,15 @@ jobs:
     steps:
       - name: Tar X64 artifacts # Below workaround will allow files to be extracted to a directory e.g. pda-v0.1-x86_64/
         if: ${{ matrix.architecture == 'X64' }}
-        run: sudo mkdir -p pda-${{ github.ref }}-x86_64 && sudo cp ./target/x86_64-unknown-linux-musl/release/performance-data-collector ./target/x86_64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref }}-x86_64 && sudo tar -cvzf pda-${{ github.ref }}-x86_64.tar.gz pda-${{ github.ref }}-x86_64/ && sudo rm -rf pda-${{ github.ref }}-x86_64
+        run: sudo mkdir -p pda-${{ github.ref_name }}-x86_64 && sudo cp ./target/x86_64-unknown-linux-musl/release/performance-data-collector ./target/x86_64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref_name }}-x86_64 && sudo tar -cvzf pda-${{ github.ref_name }}-x86_64.tar.gz pda-${{ github.ref_name }}-x86_64/ && sudo rm -rf pda-${{ github.ref_name }}-x86_64
       - name: Tar ARM64 artifacts
         if: ${{ matrix.architecture == 'ARM64' }}
-        run: sudo mkdir -p pda-${{ github.ref }}-aarch64 && sudo cp ./target/aarch64-unknown-linux-musl/release/performance-data-collector ./target/aarch64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref }}-aarch64 && sudo tar -cvzf pda-${{ github.ref }}-aarch64.tar.gz pda-${{ github.ref }}-aarch64/ && sudo rm -rf pda-${{ github.ref }}-aarch64
+        run: sudo mkdir -p pda-${{ github.ref_name }}-aarch64 && sudo cp ./target/aarch64-unknown-linux-musl/release/performance-data-collector ./target/aarch64-unknown-linux-musl/release/performance-data-visualizer ./pda-${{ github.ref_name }}-aarch64 && sudo tar -cvzf pda-${{ github.ref_name }}-aarch64.tar.gz pda-${{ github.ref_name }}-aarch64/ && sudo rm -rf pda-${{ github.ref_name }}-aarch64
       - name: Upload X64 artifacts.
         if: ${{ matrix.architecture == 'X64' }}
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "./pda-${{ github.ref }}-x86_64.tar.gz"
+          artifacts: "./pda-${{ github.ref_name }}-x86_64.tar.gz"
           replacesArtifacts: false
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
@@ -37,7 +37,7 @@ jobs:
         if: ${{ matrix.architecture == 'ARM64' }}
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "./pda-${{ github.ref }}-aarch64.tar.gz"
+          artifacts: "./pda-${{ github.ref_name }}-aarch64.tar.gz"
           replacesArtifacts: false
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true


### PR DESCRIPTION
github.ref caused issues in folder structure.

github.ref_name gives branch name while github.ref returns refs/tags/v0.1 for example.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
