### PR TITLE
Release generation for aarch64 is failing because of an error in release-action 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,10 @@ jobs:
           allowUpdates: true
       - name: Upload ARM64 artifacts
         if: ${{ matrix.architecture == 'ARM64' }}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "./pda-${{ github.ref_name }}-aarch64.tar.gz"
           replacesArtifacts: false
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
+          skipIfReleaseExists: true


### PR DESCRIPTION
Stacktrace: {"resource":"Release","code":"already_exists","field":"tag_name"} 

Related to: https://github.com/ncipollo/release-action/issues/267

Fix is to take latest version of release-action and set skipIfReleaseExists flag to true.
