### PR TITLE
Add support for collecting/visualzing Perf Stat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,7 @@ jobs:
       - name: Build for ARM64
         if: ${{ matrix.architecture == 'ARM64' }}
         run: rustup target add aarch64-unknown-linux-musl && cargo build --release --target aarch64-unknown-linux-musl
+      - name: Set perf_event_paranoid to 0
+        run: echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
       - name: Run tests
         run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,9 +1506,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -1710,6 +1710,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "perf-event"
+version = "0.4.8"
+source = "git+https://github.com/janaknat/perf-event?branch=Group#530842372b88fe689a2a0bed4ba9bbdbc09c9a68"
+dependencies = [
+ "bitflags",
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "4.0.0"
+source = "git+https://github.com/janaknat/perf-event?branch=Group#530842372b88fe689a2a0bed4ba9bbdbc09c9a68"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "performance-data-assistant"
 version = "0.1.0"
 dependencies = [
@@ -1721,8 +1739,12 @@ dependencies = [
  "ctor",
  "env_logger",
  "lazy_static",
+ "libc",
  "log",
+ "num_cpus",
+ "perf-event",
  "procfs",
+ "raw-cpuid",
  "rustix 0.35.11",
  "serde",
  "serde_json",
@@ -1946,6 +1968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,7 @@ tokio = { version = "1.24.2", features = ["full"] }
 strum = "0.24"
 strum_macros = "0.24"
 sysctl = "*"
+perf-event = { git = "https://github.com/janaknat/perf-event", branch = "Group" }
+num_cpus = "1.0"
+raw-cpuid = "10.6.0"
+libc = "0.2"

--- a/src/bin/collector.rs
+++ b/src/bin/collector.rs
@@ -30,6 +30,12 @@ fn init_logger() {
     env_logger::init_from_env(env);
 }
 
+fn prepare_data_collectors() -> Result<()> {
+    info!("Preparing data collectors...");
+    PERFORMANCE_DATA.lock().unwrap().prepare_data_collectors()?;
+    Ok(())
+}
+
 fn start_collection_serial() -> Result<()> {
     info!("Collecting data serially...");
     PERFORMANCE_DATA.lock().unwrap().collect_data_serial()?;
@@ -55,6 +61,7 @@ fn main() -> Result<()> {
     PERFORMANCE_DATA.lock().unwrap().set_params(params);
     PERFORMANCE_DATA.lock().unwrap().init_collectors()?;
     info!("Starting Performance Data collection:");
+    prepare_data_collectors()?;
     collect_static_data()?;
     start_collection_serial()?;
     Ok(())

--- a/src/bin/html_files/index.html
+++ b/src/bin/html_files/index.html
@@ -14,6 +14,7 @@
 			<button class="tablinks" name="kernel_config">Kernel Config</button>
 			<button class="tablinks" name="interrupts">Interrupt Data</button>
 			<button class="tablinks" name="disk_stats">Disk Stats</button>
+			<button class="tablinks" name="perfstat">PMU Stats</button>
 		</div>
 		<div id="system_info" class="tabcontent">
 			<div id="system-info-runs"></div>
@@ -31,6 +32,9 @@
 		</div>
 		<div id="vmstat" class="tabcontent">
 			<div id="vmstat-runs"></div>
+		</div>
+		<div id="perfstat" class="tabcontent">
+			<div id="perfstat-runs"></div>
 		</div>
 		<div id="kernel_config" class="tabcontent">
 			<div>
@@ -51,6 +55,7 @@
 		<script type="module" src="/html_files/sysctl.js"></script>
 		<script type="module" src="/html_files/cpu_utilization.js"></script>
 		<script type="module" src="/html_files/vmstat.js"></script>
+		<script type="module" src="/html_files/perf_stat.js"></script>
 		<script type="module" src="/html_files/kernel_config.js"></script>
 		<script type="module" src="/html_files/interrupts.js"></script>
 		<script type="module" src="/html_files/disk_stats.js"></script>

--- a/src/bin/html_files/index.ts
+++ b/src/bin/html_files/index.ts
@@ -5,6 +5,7 @@ import { vmStat } from './vmstat.js';
 import { kernelConfig } from './kernel_config.js';
 import { interrupts } from './interrupts.js';
 import { diskStats } from './disk_stats.js';
+import { perfStat } from './perf_stat.js';
 export { clearElements, addElemToNode, openData };
 
 function openData(evt: Event, elem: HTMLButtonElement) {
@@ -34,6 +35,9 @@ function openData(evt: Event, elem: HTMLButtonElement) {
 	}
 	if (tabName == "kernel_config") {
 		kernelConfig(false);
+	}
+	if (tabName == "perfstat") {
+		perfStat();
 	}
 	if (tabName == "interrupts") {
 		interrupts();

--- a/src/bin/html_files/perf_stat.ts
+++ b/src/bin/html_files/perf_stat.ts
@@ -1,0 +1,132 @@
+import './plotly.js';
+import { clearElements, addElemToNode } from './index.js';
+export { perfStat };
+
+function getEvents(run, container_id) {
+    const http = new XMLHttpRequest();
+    http.onload = function () {
+        if (http.response == "No data collected") {
+            var no_data_div = document.createElement('div');
+            no_data_div.id = `perfstat-${run}-nodata`;
+            no_data_div.innerHTML = "No data collected";
+            addElemToNode(container_id, no_data_div);
+        } else {
+            var data = JSON.parse(http.response);
+            data.forEach(function (value, index, arr) {
+                var elem = document.createElement('div');
+                elem.id = `perfstat-${run}-${value}`;
+                elem.style.float = "none";
+                addElemToNode(container_id, elem);
+                getEvent(run, value, elem.id);
+            })
+        }
+    }
+    http.open("GET", `visualize/perf_stat?run=${run}&get=events`);
+    http.send();
+}
+
+class StatValue {
+    cpu: number;
+    x_time: number[];
+    y_data: number[];
+}
+
+function addData(perfstat_data, stat, timediff) {
+    perfstat_data.forEach(function (value, index, arr) {
+        if (value.cpu == stat.cpu) {
+            value.x_time.push(timediff);
+            value.y_data.push(stat.value)
+        }
+    })
+}
+function getEvent(run, key, parent_id) {
+    const http = new XMLHttpRequest();
+    http.onload = function () {
+        var data = JSON.parse(http.response);
+        var perfstat_datas = [];
+        console.log(data);
+        data[0].cpus.forEach(function (value, index, arr) {
+            var cpu_stat = new StatValue();
+            cpu_stat.cpu = value.cpu;
+            cpu_stat.x_time = [];
+            cpu_stat.y_data = [];
+            perfstat_datas.push(cpu_stat);
+        });
+        console.log(perfstat_datas);
+        data.forEach(function (value, index, arr) {
+            value.cpus.forEach(function (stat, i_index, i_arr) {
+                addData(perfstat_datas, stat, value.time.TimeDiff);
+            })
+        });
+        console.log(perfstat_datas);
+        var elem = document.createElement('div');
+        elem.style.float = "none";
+        addElemToNode(parent_id, elem);
+        var TESTER = elem;
+        var end_datas = [];
+        perfstat_datas.forEach(function (value, index, arr) {
+            var cpu_string = "";
+            if (value.cpu > -1) {
+                cpu_string = `CPU ${value.cpu}`;
+            }
+            else {
+                cpu_string = `Aggregate`;
+            }
+            var perfstat_line: Partial<Plotly.PlotData> = {
+                name: cpu_string,
+                x: value.x_time,
+                y: value.y_data,
+                type: 'scatter',
+            };
+            end_datas.push(perfstat_line);
+        })
+        var layout = {
+            title: `${key}`,
+            xaxis: {
+                title: 'Time (s)',
+            },
+            yaxis: {
+                title: 'Count',
+            },
+        }
+        Plotly.newPlot(TESTER, end_datas, layout, { frameMargins: 0 });
+    }
+    http.open("GET", `visualize/perf_stat?run=${run}&get=values&key=${key}`);
+    http.send();
+}
+
+function perfStat() {
+    const http = new XMLHttpRequest();
+    http.onload = function () {
+        var data = JSON.parse(http.response);
+        var float_style = "none";
+        if (data.length > 1) {
+            float_style = "left";
+        }
+        var run_width = 100 / data.length;
+        clearElements('perfstat-runs');
+        data.forEach(function (value, index, arr) {
+            // Run div
+            var run_div = document.createElement('div');
+            run_div.id = `${value}-perfstat`;
+            run_div.style.float = float_style;
+            run_div.style.width = `${run_width}%`;
+            addElemToNode('perfstat-runs', run_div);
+            var run_node_id = run_div.id;
+
+            // Run name
+            var h3_run_name = document.createElement('h3');
+            h3_run_name.innerHTML = value;
+            h3_run_name.style.textAlign = "center";
+            addElemToNode(run_node_id, h3_run_name);
+
+            // Show data
+            var per_value_div = document.createElement('div');
+            per_value_div.id = `${value}-perfstat-per-data`;
+            addElemToNode(run_node_id, per_value_div);
+            getEvents(value, per_value_div.id);
+        })
+    }
+    http.open("GET", '/visualize/get?get=entries');
+    http.send();
+}

--- a/src/data/grv_perf_events.rs
+++ b/src/data/grv_perf_events.rs
@@ -1,0 +1,35 @@
+use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
+
+/// Graviton Events
+static INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instructions", config: 0x08};
+static CYCLES: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Cycles", config: 0x11};
+static FRONTEND_STALLS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Frontend-Stalls", config: 0x23};
+static BRANCHES: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Branches", config: 0x10};
+static CODE_SPARSITY: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Code-Sparsity", config: 0x11c};
+static INSTRUCTION_TLB: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instruction-TLB", config: 0x2};
+static INSTRUCTION_TLB_TW: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instruction-TLB-TW", config: 0x35};
+static L1_INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L1-Instructions", config: 0x1};
+static BACKEND_STALLS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Backend-Stalls", config: 0x24};
+static L3: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L3", config: 0x37};
+static L2: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L2", config: 0x17};
+static DATA_TLB: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Data-TLB", config: 0x5};
+static DATA_TLB_TW: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Data-TLB-TW", config: 0x34};
+static L1_DATA: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L1-Data", config: 0x3};
+
+lazy_static! {
+    pub static ref PERF_LIST: Vec<NamedCtr<'static>> = [
+        NamedCtr{name: "ipc", nrs: vec![INSTRUCTIONS], drs: vec![CYCLES], scale: 1},
+        NamedCtr{name: "stall-frontend-pkc", nrs: vec![FRONTEND_STALLS], drs: vec![CYCLES], scale: 1000},
+        NamedCtr{name: "branch-mpki", nrs: vec![BRANCHES], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "code-sparsity", nrs: vec![CODE_SPARSITY], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-tlb-mpki", nrs: vec![INSTRUCTION_TLB], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-tlb-tw-pki", nrs: vec![INSTRUCTION_TLB_TW], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-l1-mpki", nrs: vec![L1_INSTRUCTIONS], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "stall-backend-pkc", nrs: vec![BACKEND_STALLS], drs: vec![CYCLES], scale: 1000},
+        NamedCtr{name: "l3-mpki", nrs: vec![L3], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "l2-mpki", nrs: vec![L2], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-tlb-mpki", nrs: vec![DATA_TLB], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-tlb-tw-pki", nrs: vec![DATA_TLB_TW], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-l1-mpki", nrs: vec![L1_DATA], drs: vec![INSTRUCTIONS], scale: 1000},
+    ].to_vec();
+}

--- a/src/data/intel_perf_events.rs
+++ b/src/data/intel_perf_events.rs
@@ -1,0 +1,35 @@
+use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
+
+/// Intel Events
+static INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instructions", config: 0xc0};
+static CYCLES: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Cycles", config: 0x3c};
+static STALL_FRONTEND_PKC: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Frontend-Stalls", config: 0x9c01};
+static BRANCHES: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Branches", config: 0xc5};
+static CODE_SPARSITY: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Code-Sparsity", config: 0x4901};
+static INSTRUCTION_TLB: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instruction-TLB", config: 0x8520};
+static INSTRUCTION_TLB_TW: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Instruction-TLB-TW", config: 0x8501};
+static L1_INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L1-Instructions", config: 0x24e4};
+static BACKEND_STALLS: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Backend-Stalls", config: 0xa201};
+static L3: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L3", config: 0x2e41};
+static L2: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L2", config: 0xf11f};
+static DATA_TLB: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Data-TLB", config: 0x0820};
+static DATA_TLB_TW: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "Data-TLB-TW", config: 0x0801};
+static L1_DATA: NamedTypeCtr = NamedTypeCtr {perf_type: PerfType::RAW, name: "L1-Data", config: 0x5101};
+
+lazy_static! {
+    pub static ref PERF_LIST: Vec<NamedCtr<'static>> = [
+        NamedCtr{name: "ipc", nrs: vec![INSTRUCTIONS], drs: vec![CYCLES], scale: 1},
+        NamedCtr{name: "stall-frontend-pkc", nrs: vec![STALL_FRONTEND_PKC], drs: vec![CYCLES], scale: 1000},
+        NamedCtr{name: "branch-mpki", nrs: vec![BRANCHES], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "code-sparsity", nrs: vec![CODE_SPARSITY], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-tlb-mpki", nrs: vec![INSTRUCTION_TLB], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-tlb-tw-pki", nrs: vec![INSTRUCTION_TLB_TW], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "inst-l1-mpki", nrs: vec![L1_INSTRUCTIONS], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "stall-backend-pkc", nrs: vec![BACKEND_STALLS], drs: vec![CYCLES], scale: 1000},
+        NamedCtr{name: "l3-mpki", nrs: vec![L3], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "l2-mpki", nrs: vec![L2], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-tlb-mpki", nrs: vec![DATA_TLB], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-tlb-tw-pki", nrs: vec![DATA_TLB_TW], drs: vec![INSTRUCTIONS], scale: 1000},
+        NamedCtr{name: "data-l1-mpki", nrs: vec![L1_DATA], drs: vec![INSTRUCTIONS], scale: 1000},
+    ].to_vec();
+}

--- a/src/data/interrupts.rs
+++ b/src/data/interrupts.rs
@@ -334,6 +334,7 @@ mod tests {
         assert!(!id.data.is_empty());
     }
 
+    #[test]
     fn test_get_data_interrupt_line_values() {
         let mut buffer: Vec<Data> = Vec::<Data>::new();
         let mut id_raw = InterruptDataRaw::new();

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -1,0 +1,536 @@
+extern crate ctor;
+
+use anyhow::Result;
+use crate::data::{CollectData, Data, ProcessedData, DataType, TimeEnum};
+use crate::{PERFORMANCE_DATA, VISUALIZATION_DATA};
+use crate::visualizer::{DataVisualizer, GetData};
+use chrono::prelude::*;
+use ctor::ctor;
+use log::debug;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use perf_event::events::Raw;
+use perf_event::{Builder, Counter, Group};
+use std::io::{BufRead, BufReader, ErrorKind};
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use {
+    crate::PDError,
+    crate::data::intel_perf_events,
+    raw_cpuid::CpuId,
+};
+#[cfg(target_arch = "aarch64")]
+use crate::data::grv_perf_events;
+
+pub static PERF_STAT_FILE_NAME: &str = "perf_stat";
+
+#[derive(Copy, Clone)]
+pub enum PerfType {
+    RAW = 4,
+}
+
+lazy_static! {
+    pub static ref CPU_CTR_GROUPS: Mutex<Vec<CpuCtrGroup>> = Mutex::new(Vec::new());
+}
+
+#[derive(Debug)]
+pub struct Ctr {
+    pub perf_type: u64,
+    pub name: String,
+    pub config: u64,
+    pub counter: Counter,
+}
+
+impl Ctr {
+    fn new(perf_type: u64, name: String, cpu: usize, config: u64, group: &mut Group) -> Result<Self> {
+        let raw_config = Raw::new().config(config);
+        Ok(Ctr {
+            perf_type: perf_type,
+            name: name,
+            config: config,
+            counter: Builder::new().group(group).one_cpu(cpu).any_pid().kind(raw_config).include_kernel().build()?,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct NamedCtr<'a> {
+    pub name: &'a str,
+    pub nrs: Vec<NamedTypeCtr<'a>>,
+    pub drs: Vec<NamedTypeCtr<'a>>,
+    pub scale: u64,
+}
+
+#[derive(Copy, Clone)]
+pub struct NamedTypeCtr<'a> {
+    pub perf_type: PerfType,
+    pub name: &'a str,
+    pub config: u64,
+}
+
+#[derive(Debug)]
+pub struct CpuCtrGroup {
+    pub cpu: u64,
+    pub name: String,
+    pub nr_ctrs: Vec<Ctr>,
+    pub dr_ctrs: Vec<Ctr>,
+    pub scale: u64,
+    pub group: Group,
+}
+
+impl CpuCtrGroup {
+    fn nr_ctr_add(&mut self, ctr: Ctr) {
+        self.nr_ctrs.push(ctr);
+    }
+    fn dr_ctr_add(&mut self, ctr: Ctr) {
+        self.dr_ctrs.push(ctr);
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PerfStatRaw {
+    pub time: TimeEnum,
+    pub data: String,
+}
+
+impl PerfStatRaw {
+    fn new() -> Self {
+        PerfStatRaw {
+            time: TimeEnum::DateTime(Utc::now()),
+            data: String::new(),
+        }
+    }
+}
+
+impl CollectData for PerfStatRaw {
+    fn prepare_data_collector(&mut self) -> Result<()> {
+        let num_cpus = num_cpus::get();
+        let mut cpu_groups: Vec<CpuCtrGroup> = Vec::new();
+        let perf_list;
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            perf_list = grv_perf_events::PERF_LIST.to_vec();
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            let cpuid = CpuId::new();
+            let vendor_info = cpuid.get_vendor_info().unwrap();
+            if vendor_info.as_str() == "GenuineIntel" {
+                perf_list = intel_perf_events::PERF_LIST.to_vec();
+            } else {
+                return Err(PDError::CollectorPerfUnsupportedCPU.into())
+            }
+        }
+        for cpu in 0..num_cpus {
+            for named_ctr in &perf_list {
+                let perf_group = Group::new_task_cpu(-1, cpu.try_into()?);
+                let group: Group;
+                match perf_group {
+                    Err(e) => {
+                        match e.kind() {
+                            ErrorKind::PermissionDenied => println!("Set /proc/sys/kernel/perf_event_paranoid to 0"),
+                            ErrorKind::NotFound => println!("Instance does not expose Perf counters"),
+                            _ => println!("Unknown error when trying to use Perf API"),
+                        }
+                        return Err(e.into());
+                    }
+                    Ok(g) => group = g,
+                }
+                let mut cpu_group = CpuCtrGroup {
+                    cpu: cpu as u64,
+                    name: named_ctr.name.to_string(),
+                    nr_ctrs: Vec::new(),
+                    dr_ctrs: Vec::new(),
+                    scale: named_ctr.scale,
+                    group: group
+                };
+                for nr in &named_ctr.nrs {
+                    let nr_ctr = Ctr::new(
+                        nr.perf_type as u64,
+                        nr.name.to_string(),
+                        cpu,
+                        nr.config,
+                        &mut cpu_group.group
+                    );
+                    match nr_ctr {
+                        Err(e) => {
+                            if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
+                                match os_error.kind() {
+                                    ErrorKind::NotFound => println!("Instance does not expose Perf counters"),
+                                    _ => {
+                                        match os_error.raw_os_error().unwrap() {
+                                            libc::EMFILE => println!("Too many open files. Increase limit with `ulimit -n`"),
+                                            _ => println!("Unknown error when trying to use Perf API."),
+                                        }
+                                    }
+                                }
+                                return Err(e.into());
+                            }
+                        }
+                        Ok(v) => cpu_group.nr_ctr_add(v),
+                    }
+                }
+                for dr in &named_ctr.drs {
+                    let dr_ctr = Ctr::new(
+                        dr.perf_type as u64,
+                        dr.name.to_string(),
+                        cpu,
+                        dr.config,
+                        &mut cpu_group.group
+                    );
+                    match dr_ctr {
+                        Err(e) => {
+                            if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
+                                match os_error.kind() {
+                                    ErrorKind::NotFound => println!("Instance does not expose Perf counters"),
+                                    _ => {
+                                        match os_error.raw_os_error().unwrap() {
+                                            libc::EMFILE => println!("Too many open files. Increase limit with `ulimit -n`"),
+                                            _ => println!("Unknown error when trying to use Perf API."),
+                                        }
+                                    }
+                                }
+                                return Err(e.into());
+                            }
+                        }
+                        Ok(v) => cpu_group.dr_ctr_add(v),
+                    }
+                }
+                cpu_groups.push(cpu_group);
+            }
+        }
+        for cpu_group in &mut *cpu_groups {
+            cpu_group.group.reset()?;
+            cpu_group.group.enable()?;
+        }
+        CPU_CTR_GROUPS.lock().unwrap().append(&mut cpu_groups);
+        Ok(())
+    }
+
+    fn collect_data(&mut self) -> Result<()> {
+        self.time = TimeEnum::DateTime(Utc::now());
+        self.data = String::new();
+        let cpu_groups = &mut *CPU_CTR_GROUPS.lock().unwrap();
+        for cpu_group in &mut *cpu_groups {
+            let count = cpu_group.group.read()?;
+            let mut group_data = format!("{} {};", cpu_group.cpu, cpu_group.name.clone());
+            for nr in &cpu_group.nr_ctrs {
+                let nr_string = format!(" {}", count[&nr.counter]);
+                group_data.push_str(&nr_string);
+            }
+            group_data.push_str(";");
+            for dr in &cpu_group.dr_ctrs {
+                let dr_string = format!(" {}", count[&dr.counter]);
+                group_data.push_str(&dr_string);
+            }
+            group_data.push_str(";");
+            let scale_string = format!("{}", cpu_group.scale);
+            group_data.push_str(&scale_string);
+            group_data.push_str("\n");
+            cpu_group.group.reset()?;
+            self.data.push_str(&group_data);
+        }
+        debug!("{:#?}", self.data);
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PerfStat {
+    pub perf_stats: Vec<PerCPUNamedStats>,
+}
+
+impl PerfStat {
+    fn new() -> Self {
+        PerfStat {
+            perf_stats: Vec::new(),
+        }
+    }
+
+    fn add_named_stat(&mut self, cpu: u64, stat: NamedStat) {
+        for per_cpu_named_stat in &mut self.perf_stats {
+            if per_cpu_named_stat.cpu == cpu {
+                per_cpu_named_stat.named_stats.push(stat);
+                return;
+            }
+        }
+        let mut per_cpu_named_stats = PerCPUNamedStats {
+            cpu,
+            named_stats: Vec::new(),
+        };
+        per_cpu_named_stats.named_stats.push(stat);
+        self.perf_stats.push(per_cpu_named_stats);
+        return;
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PerCPUNamedStats {
+    pub cpu: u64,
+    pub named_stats: Vec<NamedStat>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamedStat {
+    pub time: TimeEnum,
+    pub name: String,
+    pub nr_value: u64,
+    pub dr_value: u64,
+    pub scale: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EndStat {
+    pub cpu: i64,
+    pub value: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EndStats {
+    pub time: TimeEnum,
+    pub cpus: Vec<EndStat>,
+}
+
+impl EndStats {
+    fn new() -> Self {
+        EndStats {
+            time: TimeEnum::DateTime(Utc::now()),
+            cpus: Vec::new(),
+        }
+    }
+}
+
+pub struct InterStat {
+    pub cpu: u64,
+    pub named_stat: NamedStat,
+}
+
+fn get_named_stat_for_all_cpus(value: PerfStat, key: String) -> Vec<InterStat> {
+    let mut named_stats = Vec::new();
+    for per_cpu_named_stat in value.perf_stats {
+        for named_stat in per_cpu_named_stat.named_stats {
+            if named_stat.name == key {
+                named_stats.push(InterStat {cpu: per_cpu_named_stat.cpu, named_stat: named_stat});
+                break;
+            }
+        }
+    }
+    return named_stats;
+}
+
+fn get_values(values: Vec<PerfStat>, key: String) -> Result<String> {
+    let time_zero = &values[0].perf_stats[0].named_stats[0].time;
+    let mut end_values = Vec::new();
+    let mut aggregate_value: f64;
+    for value in &values {
+        let mut end_stats = EndStats::new();
+        let mut end_cpu_stats = Vec::new();
+        let stats = get_named_stat_for_all_cpus(value.clone(), key.clone());
+        let mut aggregate_nr = 0;
+        let mut aggregate_dr = 0;
+        for stat in &stats {
+            let this_cpu_end_stat_value = stat.named_stat.nr_value as f64 / stat.named_stat.dr_value as f64;
+            let this_cpu_end_stat = EndStat { cpu: stat.cpu as i64, value: this_cpu_end_stat_value * stat.named_stat.scale as f64 };
+            end_cpu_stats.push(this_cpu_end_stat);
+            aggregate_nr += stat.named_stat.nr_value;
+            aggregate_dr += stat.named_stat.dr_value;
+        }
+        aggregate_value = (aggregate_nr as f64 / aggregate_dr as f64) * stats[0].named_stat.scale as f64;
+        let aggr_cpu_stat = EndStat { cpu: -1, value: aggregate_value };
+        end_cpu_stats.push(aggr_cpu_stat);
+
+        end_stats.time = stats[0].named_stat.time - *time_zero;
+        end_stats.cpus = end_cpu_stats;
+        end_values.push(end_stats);
+    }
+    Ok(serde_json::to_string(&end_values)?)
+}
+
+fn get_named_events(value: PerfStat) -> Result<String> {
+    let mut evt_names = Vec::new();
+    let named_stats = &value.perf_stats[0].named_stats;
+    for stat in named_stats {
+        evt_names.push(stat.name.clone());
+    }
+    Ok(serde_json::to_string(&evt_names)?)
+}
+
+impl GetData for PerfStat {
+    fn process_raw_data(&mut self, buffer: Data) -> Result<ProcessedData> {
+        let mut perf_stat = PerfStat::new();
+        let raw_value = match buffer {
+            Data::PerfStatRaw(ref value) => value,
+            _ => panic!("Invalid Data type in raw file"),
+        };
+        let reader = BufReader::new(raw_value.data.as_bytes());
+        for line in reader.lines() {
+            let line = line?;
+            let line_str: Vec<&str> = line.split(';').collect();
+
+            // CPU and Stat name
+            let mut cpu_and_name: Vec<&str> = line_str[0].split_whitespace().collect();
+            let cpu = cpu_and_name[0].parse::<u64>();
+            cpu_and_name.remove(0);
+            let stat_name = cpu_and_name.join(" ");
+
+            // Numerators
+            let nr_split: Vec<&str> = line_str[1].split_whitespace().collect();
+            let mut nr_value: u64 = 0;
+            for nr in nr_split {
+                nr_value += nr.parse::<u64>()?;
+            }
+
+            // Denominators
+            let dr_split: Vec<&str> = line_str[2].split_whitespace().collect();
+            let mut dr_value: u64 = 0;
+            for dr in dr_split {
+                dr_value += dr.parse::<u64>()?;
+            }
+
+            let scale: u64 = line_str[3].parse::<u64>()?;
+
+            let named_stat = NamedStat {
+                time: raw_value.time,
+                name: stat_name.to_string(),
+                nr_value,
+                dr_value,
+                scale
+            };
+            perf_stat.add_named_stat(cpu?, named_stat);
+        }
+        let processed_data = ProcessedData::PerfStat(perf_stat);
+        Ok(processed_data)
+    }
+
+    fn get_data(&mut self, buffer: Vec<ProcessedData>, query: String) -> Result<String> {
+        let mut values = Vec::new();
+        for data in buffer {
+            match data {
+                ProcessedData::PerfStat(ref value) => values.push(value.clone()),
+                _ => unreachable!(),
+            }
+        }
+        let param: Vec<(String, String)> = serde_urlencoded::from_str(&query).unwrap();
+        if param.len() < 2 {
+            panic!("Not enough arguments");
+        }
+        let (_, req_str) = &param[1];
+
+        match req_str.as_str() {
+            "events" => return get_named_events(values[0].clone()),
+            "values" => {
+                let (_, key) = &param[2];
+                return get_values(values, key.to_string());
+            }
+            _ => panic!("Unsupported API"),
+        }
+    }
+}
+
+#[ctor]
+fn init_perf_stat_raw() {
+    let perf_stat_raw = PerfStatRaw::new();
+    let file_name = PERF_STAT_FILE_NAME.to_string();
+    let dt = DataType::new(
+        Data::PerfStatRaw(perf_stat_raw.clone()),
+        file_name.clone(),
+        false
+    );
+    let js_file_name = file_name.clone() + &".js".to_string();
+    let perf_stat = PerfStat::new();
+    let dv = DataVisualizer::new(
+        ProcessedData::PerfStat(perf_stat.clone()),
+        file_name.clone(),
+        js_file_name,
+        include_str!(concat!(env!("JS_DIR"), "/perf_stat.js")).to_string(),
+        file_name.clone(),
+    );
+
+    PERFORMANCE_DATA
+        .lock()
+        .unwrap()
+        .add_datatype(file_name.clone(), dt);
+
+    VISUALIZATION_DATA
+        .lock()
+        .unwrap()
+        .add_visualizer(file_name.clone(), dv);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PerfStat, PerfStatRaw};
+    use crate::data::{CollectData, Data, ProcessedData};
+    use crate::visualizer::GetData;
+    use std::collections::HashMap;
+    use std::io::ErrorKind;
+
+    #[test]
+    fn test_collect_data() {
+        let mut perf_stat = PerfStatRaw::new();
+
+        match perf_stat.prepare_data_collector() {
+            Err(e) => {
+                if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
+                    match os_error.kind() {
+                        ErrorKind::PermissionDenied => assert!(false, "Set /proc/sys/kernel/perf_event_paranoid to 0"),
+                        ErrorKind::NotFound => assert!(true, "Instance does not expose Perf counters"),
+                        _ => assert!(false, "{}", os_error),
+                    }
+                }
+            }
+            Ok(v) => {
+                assert!(v == ());
+                assert!(perf_stat.collect_data().unwrap() == ());
+                assert!(!perf_stat.data.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_named_events() {
+        let mut perf_stat = PerfStatRaw::new();
+        let mut buffer: Vec<Data> = Vec::<Data>::new();
+        let mut processed_buffer: Vec<ProcessedData> = Vec::new();
+
+        match perf_stat.prepare_data_collector() {
+            Err(e) => {
+                if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
+                    match os_error.kind() {
+                        ErrorKind::PermissionDenied => assert!(false, "Set /proc/sys/kernel/perf_event_paranoid to 0"),
+                        ErrorKind::NotFound => assert!(true, "Instance does not expose Perf counters"),
+                        _ => assert!(false, "{}", os_error),
+                    }
+                }
+            }
+            Ok(v) => {
+                assert!(v == ());
+                perf_stat.collect_data().unwrap();
+                buffer.push(Data::PerfStatRaw(perf_stat));
+                for buf in buffer {
+                    processed_buffer.push(PerfStat::new().process_raw_data(buf).unwrap());
+                }
+                let events = PerfStat::new().get_data(processed_buffer, "run=test&get=events".to_string()).unwrap();
+                let values: Vec<&str> = serde_json::from_str(&events).unwrap();
+                let mut key_map = HashMap::new();
+                let event_names = [
+                    "ipc", "branch-mpki", "data-l1-mpki", "inst-l1-mpki", "l2-mpki",
+                    "l3-mpki", "stall-frontend-pkc", "stall-backend-pkc", "inst-tlb-mpki",
+                    "inst-tlb-tw-pki", "data-tlb-mpki", "data-tlb-tw-pki", "code-sparsity"
+                ];
+                for name in event_names {
+                    key_map.insert(name.to_string(), 0);
+                }
+                for event in values {
+                    assert!(key_map.contains_key(&event.to_string()));
+                    let value = key_map.get(&event.to_string()).unwrap() + 1;
+                    key_map.insert(event.to_string(), value);
+                }
+                let mut key_values: Vec<u64> = key_map.into_values().collect();
+                key_values.dedup();
+                assert!(key_values.len() == 1);
+            }
+        }
+    }
+}

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -73,7 +73,7 @@ pub trait GetData {
 #[cfg(test)]
 mod tests {
     use crate::data::cpu_utilization::{CpuData, CpuUtilization};
-    use crate::data::{Data, ProcessedData, TimeEnum};
+    use crate::data::{ProcessedData, TimeEnum};
     use super::DataVisualizer;
 
     #[test]


### PR DESCRIPTION
Add support for collecting and visualizing perf events collected with the Perf API. The events collected are documented in the [aws-getting-started-guide](https://github.com/aws/aws-graviton-getting-started/blob/main/perfrunbook/utilities/measure_and_plot_basic_pmu_counters.py#L92).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
