### PR TITLE
Fix visualization of interrupt data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ pub enum PDError {
     #[error("Error getting Vmstat value for {}", .0)]
     VisualizerVmstatValueGetError(String),
 
+    #[error("Error getting interrupt line count for CPU {}", .0)]
+    VisualizerInterruptLineCPUCountError(String),
+
     #[error("Error getting Line Name Error")]
     CollectorLineNameError,
 


### PR DESCRIPTION
The data from procfs for interrupts is cumulative.

Data for time (t) = data for time (t) - data for time (t-1)
