### PR TITLE
Use Path to form the file_names

### DIFF
--- a/src/bin/html_files/index.html
+++ b/src/bin/html_files/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<link rel="stylesheet" href="/html_files/index.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>APerf</title>
 	</head>
 	<body>
 		<h2>APerf</h2>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,8 @@ pub fn get_file(dir: String, name: String) -> Result<fs::File> {
     for path in fs::read_dir(dir.clone())? {
         let mut file_name = path?.file_name().into_string().unwrap();
         if file_name.contains(&name) {
-            file_name = dir + &file_name;
+            let file_path = Path::new(&dir).join(file_name.clone());
+            file_name = file_path.to_str().unwrap().to_string();
             return Ok(fs::OpenOptions::new()
                 .read(true)
                 .open(file_name)


### PR DESCRIPTION
The current approach fails if the user does not specify the directory with a trailing /.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
