### PR TITLE
BUG: Sys:new_all() is taking too much time to scan all the resources …

### DIFF
--- a/src/data/systeminfo.rs
+++ b/src/data/systeminfo.rs
@@ -108,8 +108,8 @@ impl EC2Metadata {
 
 impl CollectData for SystemInfo {
     fn collect_data(&mut self) -> Result<()> {
-        let mut sys = System::new_all();
-        sys.refresh_all();
+        let mut sys = System::new();
+        sys.refresh_system();
 
         self.set_system_name(sys.name().unwrap());
         self.set_kernel_version(sys.kernel_version().unwrap());


### PR DESCRIPTION
```
dev-dsk-yugesk-1e-336bb03f % time ./aperf-collector                       
[2023-02-17T21:43:37Z INFO  aperf_collector] To see debug messages export APERF_LOG_LEVEL=[debug|trace]
[2023-02-17T21:43:37Z INFO  aperf] No run-name given. Using aperf_2023-02-17_21_43_37
[2023-02-17T21:43:37Z INFO  aperf_collector] Starting Data collection...
[2023-02-17T21:43:37Z INFO  aperf_collector] Preparing data collectors...
[2023-02-17T21:43:37Z ERROR aperf::data::perf_stat] Set /proc/sys/kernel/perf_event_paranoid to 0
[2023-02-17T21:43:37Z ERROR aperf] Excluding perf_stat from collection
[2023-02-17T21:43:37Z INFO  aperf_collector] Collecting static data...
[2023-02-17T21:43:38Z WARN  aws_config::profile::parser::normalize] profile `aperf` ignored because config profiles must be of the form `[profile <name>]`
[2023-02-17T21:43:38Z INFO  aperf_collector] Collecting data...
[2023-02-17T21:43:49Z INFO  aperf_collector] Data collection complete.
./aperf-collector  0.11s user 0.32s system 3% cpu 11.443 total

(23-02-17 21:43:49) <0> [~/workplace/performance-data-assistant/target/x86_64-unknown-linux-musl/release]  
dev-dsk-yugesk-1e-336bb03f % cat aperf_2023-02-17_21_43_37/system_info_2023-02-17_21_43_37.yaml 
---
SystemInfo:
  time:
    DateTime: "2023-02-17T21:43:37.685907244Z"
  system_name: Amazon Linux
  kernel_version: 5.4.228-141.415.amzn2int.x86_64
  os_version: "2"
  host_name: dev-dsk-yugesk-1e-336bb03f.us-east-1.amazon.com
  total_cpus: 16
  instance_metadata:
    instance_id: i-0540035343937ca3e
    local_hostname: ip-10-189-59-169.amazon.com
    ami_id: ami-09adb5d8fb4c27a25
    region: us-east-1
    instance_type: m5.4xlarge
```