### PR TITLE
Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: APerf-${{ github.ref }}
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
           draft: false
           prerelease: false
       - name: Upload X64 artifacts.


### PR DESCRIPTION
"Error: Error 422: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}"

This was previously passing and we have version of the action locked too.

Moving to a new process which uses a different plugin for creating release and uploading artifacts.

#### testing
Not tested yet. 