### PR TITLE
Update raw interrupt processing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ pub enum PDError {
 
     #[error("Unsupported API")]
     VisualizerUnsupportedAPI,
+
+    #[error("Visuailzer Init error")]
+    VisualizerInitError,
 }
 
 lazy_static! {
@@ -230,7 +233,8 @@ impl VisualizationData {
     }
 
     pub fn unpack_data(&mut self, name: String) -> Result<()> {
-        for (_, datavisualizer) in self.visualizers.iter_mut() {
+        for (dvname, datavisualizer) in self.visualizers.iter_mut() {
+            debug!("Processing: {}", dvname);
             datavisualizer.process_raw_data(name.clone())?;
         }
         Ok(())

--- a/test/aperf_2022-01-01_01_01_01/interrupts_2022-01-01_01_01_01.yaml
+++ b/test/aperf_2022-01-01_01_01_01/interrupts_2022-01-01_01_01_01.yaml
@@ -1,0 +1,5 @@
+---
+InterruptDataRaw:
+  time:
+    DateTime: "2022-01-01T01:01:01.000000000Z"
+  data: "           CPU0       CPU1       CPU2       CPU3       CPU4       CPU5       CPU6       CPU7       \n 123:0          0          0          0          0          0         0    0   PCI edge      device\n"


### PR DESCRIPTION
In some cases, interrupt lines don't have the whitespace as aperf is expecting. Change the split logic to look at whitespaces and ':'. Also, update the visualizer to explicitly check for Err instead of unwrapping().

Ex:
Previously, aperf was expecting:
```
\nIPI1:  0
```
In cases where it is:
```
\nIPI1:0
```
aperf raw interrupt processing fails. To avoid this use ':' in addition to whitespaces to look for the INTR line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
