### PR TITLE
Explicitly use sysconf to get total CPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "num_cpus",
  "perf-event",
  "procfs",
  "raw-cpuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,5 @@ strum = "0.24"
 strum_macros = "0.24"
 sysctl = "*"
 perf-event = { git = "https://github.com/janaknat/perf-event", branch = "Group" }
-num_cpus = "1.0"
 raw-cpuid = "10.6.0"
 libc = "0.2"

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -104,7 +104,14 @@ impl PerfStatRaw {
 
 impl CollectData for PerfStatRaw {
     fn prepare_data_collector(&mut self) -> Result<()> {
-        let num_cpus = num_cpus::get();
+        let num_cpus;
+        match unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN as libc::c_int) } {
+            -1 => {
+                error!("Could not get the number of cpus in the system");
+                return Err(PDError::CollectorPMUCPUCountError.into());
+            },
+            ret => num_cpus = ret as usize,
+        }
         let mut cpu_groups: Vec<CpuCtrGroup> = Vec::new();
         let perf_list;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ pub enum PDError {
 
     #[error("Visuailzer Init error")]
     VisualizerInitError,
+
+    #[error("Collector PMU CPUs count error")]
+    CollectorPMUCPUCountError,
 }
 
 lazy_static! {


### PR DESCRIPTION
The num_cpus crate checks for schedaffinity and queries for the total number of CPUs in the system using CPU_SETSIZE. This will cause the cpu count to be incorrect in systems where CGROUPS and schedaffinity rules are applied to aperf. Use sysconf to query for the total number of online CPUs in the system.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
