### PR TITLE
Update Diskstats

### DIFF
--- a/src/bin/html_files/disk_stats.ts
+++ b/src/bin/html_files/disk_stats.ts
@@ -2,7 +2,7 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { diskStats };
 
-function getStatValues(run, key, elem) {
+function getStatValues(run, key, elem, unit) {
     const http = new XMLHttpRequest();
     http.onload = function () {
         var disk_datas = [];
@@ -34,11 +34,15 @@ function getStatValues(run, key, elem) {
         };
         Plotly.newPlot(TESTER, disk_datas, layout, { frameMargins: 0 });
     }
-    http.open("GET", `visualize/disk_stats?run=${run}&get=values&key=${key.name}`);
+    http.open("GET", `visualize/disk_stats?run=${run}&get=values&key=${key.name}&unit=${unit}`);
     http.send();
 }
 
-function getStatKeys(run, container_id) {
+function getStatKeys(run, container_id, mb) {
+    var unit = "KB";
+    if (mb) {
+	unit = "MB";
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -47,14 +51,14 @@ function getStatKeys(run, container_id) {
             elem.id = `disk-stat-${run}-${value.name}`;
             elem.style.float = "none";
             addElemToNode(container_id, elem);
-            getStatValues(run, value, elem);
+            getStatValues(run, value, elem, unit);
         })
     }
-    http.open("GET", `visualize/disk_stats?run=${run}&get=keys`);
+    http.open("GET", `visualize/disk_stats?run=${run}&get=keys&unit=${unit}`);
     http.send();
 }
 
-function diskStats() {
+function diskStats(mb: boolean) {
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -83,7 +87,7 @@ function diskStats() {
             var per_value_div = document.createElement('div');
             per_value_div.id = `${value}-disk-stat-per-data`;
             addElemToNode(run_node_id, per_value_div);
-            getStatKeys(value, per_value_div.id);
+            getStatKeys(value, per_value_div.id, mb);
         })
     }
     http.open("GET", '/visualize/get?get=entries');

--- a/src/bin/html_files/index.html
+++ b/src/bin/html_files/index.html
@@ -49,6 +49,10 @@
 			<div id="interrupt-runs"></div>
 		</div>
 		<div id="disk_stats" class="tabcontent">
+			<div>
+				<input type="radio" class="disk-button" id="disk_button_kb" name="diskBytes">KB (Kilobytes)</button>
+				<input type="radio" class="disk-button" id="disk_button_mb" name="diskBytes">MB (Megabytes)</button>
+			</div>
 			<div id="disk-stat-runs"></div>
 		</div>
 		<script type="module" src="/html_files/index.js"></script>

--- a/src/bin/html_files/index.ts
+++ b/src/bin/html_files/index.ts
@@ -43,7 +43,7 @@ function openData(evt: Event, elem: HTMLButtonElement) {
 		interrupts();
 	}
 	if (tabName == "disk_stats") {
-		diskStats();
+		diskStats(false);
 	}
 }
 // Collapse functionality
@@ -84,6 +84,16 @@ for (var i=0; i < elems.length; i++) {
 			sysctl(true);
 		} else {
 			sysctl(false);
+		}
+	})
+}
+var elems = document.getElementsByClassName('disk-button');
+for (var i=0; i < elems.length; i++) {
+	elems[i].addEventListener("click", function(evn: Event) {
+		if (this.id == "disk_button_kb"){
+			diskStats(false);
+		} else {
+			diskStats(true);
 		}
 	})
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,6 +10,7 @@ pub mod perf_stat;
 pub mod intel_perf_events;
 #[cfg(target_arch = "aarch64")]
 pub mod grv_perf_events;
+pub mod constants;
 
 use anyhow::Result;
 use crate::InitParams;

--- a/src/data/constants.rs
+++ b/src/data/constants.rs
@@ -1,0 +1,4 @@
+pub static KB_FACTOR: u64 = 1024;
+pub static MB_FACTOR: u64 = 1048576;
+pub static TIME_S_FACTOR: u64 = 1000;
+pub static FACTOR_OF_ONE: u64 = 1;


### PR DESCRIPTION
Use the data at time t when calculating the data for time t+1. Update the visualizer for diskstats to include units. Provide an option to view the graphs in kb or mb. The visualizer backend is also updated to calculate the kb/mb view and time in seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
