### PR TITLE
Visualizer updates

### DIFF
--- a/src/bin/html_files/cpu_utilization.ts
+++ b/src/bin/html_files/cpu_utilization.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { cpuUtilization };
 
+let got_data = false;
+
 function getUtilizationType(run, elem, type) {
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -137,6 +139,7 @@ function getCpuUtilization(elem, run) {
             },
             yaxis: {
                 title: 'CPU Utilization (%)',
+                range: [0, 100],
             },
         };
         var data_list = [user, nice, system, irq, softirq, idle, iowait, steal];
@@ -146,6 +149,9 @@ function getCpuUtilization(elem, run) {
     http.send();
 }
 function cpuUtilization() {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -179,6 +185,7 @@ function cpuUtilization() {
             addElemToNode(run_node_id, per_type_div);
             getUtilizationTypes(value, per_type_div.id);
         });
+        got_data = true;
     };
     http.open("GET", '/visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/disk_stats.ts
+++ b/src/bin/html_files/disk_stats.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { diskStats };
 
+let got_data = false;
+
 function getStatValues(run, key, elem, unit) {
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -59,6 +61,9 @@ function getStatKeys(run, container_id, mb) {
 }
 
 function diskStats(mb: boolean) {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -89,6 +94,7 @@ function diskStats(mb: boolean) {
             addElemToNode(run_node_id, per_value_div);
             getStatKeys(value, per_value_div.id, mb);
         })
+        got_data = true;
     }
     http.open("GET", '/visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/interrupts.ts
+++ b/src/bin/html_files/interrupts.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { interrupts };
 
+let got_data = false;
+
 function getLine(run, key, elem) {
     const http = new XMLHttpRequest();
     http.onload = function() {
@@ -66,6 +68,9 @@ function getLines(run, container_id) {
 }
 
 function interrupts() {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -96,6 +101,7 @@ function interrupts() {
             addElemToNode(run_node_id, per_value_div);
             getLines(value, per_value_div.id);
         })
+        got_data = true;
     }
     http.open("GET", '/visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/kernel_config.ts
+++ b/src/bin/html_files/kernel_config.ts
@@ -1,61 +1,88 @@
 import { clearElements, addElemToNode } from "./index.js";
 export { kernelConfig };
 
-var diff_data: Array<Entry> = [];
-var common_data: Array<Entry> = [];
-class Entry {
+let got_data = false;
+let current_diff_status = false;
+
+var runs: Map<string, RunEntry> = new Map<string, RunEntry>();
+var run_names: Array<string> = [];
+var common_keys: Array<string> = [];
+
+class RunEntry {
     run: string;
-    title: string;
-    value: string;
+    entries: Map<string, string>;
+    diff_keys: Array<string>;
+    raw_entries: string;
 }
 
-function addEntry(entry: Entry) {
-    var add = true;
-    for (let i = 0; i < common_data.length; i++) {
-        if (common_data[i].title == entry.title &&
-            common_data[i].value == entry.value) {
-                return;
-            }
-    }
-    for (let i = 0; i < diff_data.length; i++) {
-        if (diff_data[i].title == entry.title &&
-            diff_data[i].value == entry.value) {
-                common_data.push(entry);
-                diff_data.splice(i, 1);
-                return;
-            }
-    }
-    diff_data.push(entry);
-}
-
-function containsEntry(title: string) {
-    var found = false;
-    diff_data.forEach(function (value, index, arr) {
-        if (value.title == title) {
-            found = true;
+function checkIsCommonKey(title: string) {
+    for (let check_key of common_keys) {
+        if (check_key == title) {
+            return true;
         }
-    })
-    return found;
+    }
+    let common_entry_across_runs = true;
+    for (let [key, value] of runs) {
+        if (value.entries.has(title)) {
+            continue;
+        } else {
+            common_entry_across_runs = false;
+            return false;
+        }
+    }
+    if (common_entry_across_runs) {
+        for (let [key, value] of runs) {
+            for (let i = 0; i < value.diff_keys.length; i++) {
+                if (value.diff_keys[i] == title) {
+                    value.diff_keys.splice(i, 1);
+                }
+            }
+        }
+        common_keys.push(title);
+        return true;
+    }
 }
 
-function createEntries(container_id, values, level, run, diff) {
+function isDiffAcrossRuns(title: string) {
+    let title_value = runs.get(run_names[0]).entries.get(title);
+    for (let [key, value] of runs) {
+        if (title_value != value.entries.get(title)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function createNode(key, value, container_id) {
+    var dt = document.createElement('dt');
+    dt.innerHTML = `${key} = ${value}`;
+    addElemToNode(container_id, dt);
+}
+
+function createEntries(container_id, values, level, run, store) {
     values?.forEach(function(value, index, arr) {
         for (var prop in value) {
             if ('value' in value[prop]) {
-                if (diff && !containsEntry(value[prop].name)) {
-                    continue;
-                }
                 var dt = document.createElement('dt');
                 dt.style.textIndent = `${level * 5}%`;
                 dt.style.fontWeight = "normal";
                 dt.innerHTML = `${value[prop].name} = ${value[prop].value}`;
                 addElemToNode(container_id, dt);
-                if (!diff) {
-                    var entry = new Entry();
-                    entry.run = run;
-                    entry.title = value[prop].name;
-                    entry.value = value[prop].value;
-                    addEntry(entry);
+                if (store) {
+                    let run_entry = runs.get(run);
+                    let title = value[prop].name;
+                    let title_value = value[prop].value;
+                    run_entry.entries.set(title, title_value);
+                    if (checkIsCommonKey(title)) {
+                        for (let i = 0; i < run_entry.diff_keys.length; i++) {
+                            if (run_entry.diff_keys[i] == title) {
+                                run_entry.diff_keys.splice(i, 1);
+                                break;
+                            }
+                        }
+                    } else {
+                        run_entry.diff_keys.push(title);
+                    }
                 }
             } else {
                 var dl = document.createElement('dl');
@@ -64,7 +91,7 @@ function createEntries(container_id, values, level, run, diff) {
                 dl.style.fontWeight = "bold";
                 dl.id = `${run}-${value[prop].name}`;
                 addElemToNode(container_id, dl);
-                createEntries(dl.id, value[prop].entries, level + 1, run, diff);
+                createEntries(dl.id, value[prop].entries, level + 1, run, store);
             }
         }
     });
@@ -72,29 +99,84 @@ function createEntries(container_id, values, level, run, diff) {
 
 function getKernelConfig(run, container_id, diff) {
     const http = new XMLHttpRequest();
+    run_names.push(run);
+    var run_entry = new RunEntry();
+    run_entry.run = run;
+    run_entry.entries = new Map<string, string>();
+    run_entry.diff_keys = new Array();
+    runs.set(run, run_entry);
     http.onload = function () {
         var data = JSON.parse(http.response);
         var dl = document.createElement('dl');
-        dl.id = `${run}-kernel-config`;
+        dl.id = `${run}-dl-kernel-config`;
         dl.style.float = "none";
         var dl_id = dl.id;
         addElemToNode(container_id, dl);
+        runs.get(run).raw_entries = http.response;
         data.forEach(function (value, index, arr) {
             var dt = document.createElement('dl');
             dt.id = `${run}-${value.name}`;
             dt.style.fontWeight = "bold";
             dt.innerHTML = value.name;
             addElemToNode(dl_id, dt);
-            createEntries(dt.id, value.entries, 1, run, diff);
+            createEntries(dt.id, value.entries, 1, run, true);
         });
     }
     http.open("GET", `visualize/kernel_config?run=${run}&get=values`);
     http.send();
 }
 
+function redoKernelConfig(diff) {
+    run_names.forEach(function (value, index, array) {
+        var agg_id = `${value}-kernel-config-div`;
+        clearElements(agg_id);
+        var dl = document.createElement('dl');
+        dl.id = `${value}-dl-kernel-config`;
+        dl.style.float = "none";
+        var dl_id = dl.id;
+        addElemToNode(agg_id, dl);
+        let run_entry = runs.get(value);
+        if (diff) {
+            var h3_common = document.createElement('h3');
+            h3_common.innerHTML = 'Common Keys';
+            h3_common.style.textAlign = "center";
+            addElemToNode(dl_id, h3_common);
+            for (let i = 0; i < common_keys.length; i++) {
+                if (isDiffAcrossRuns(common_keys[i])) {
+                    let e = run_entry.entries.get(common_keys[i]);
+                    createNode(common_keys[i], e, dl_id);
+                }
+            }
+            var h3_diff = document.createElement('h3');
+            h3_diff.innerHTML = 'Different Keys';
+            h3_diff.style.textAlign = "center";
+            addElemToNode(dl_id, h3_diff);
+            for (let i = 0; i < run_entry.diff_keys.length; i++) {
+                let key = run_entry.diff_keys[i];
+                let e = run_entry.entries.get(key);
+                createNode(key, e, dl_id);
+            }
+        } else {
+            let data = JSON.parse(run_entry.raw_entries);
+            data.forEach(function (value, index, arr) {
+                var dt = document.createElement('dl');
+                dt.id = `${run_entry.run}-${value.name}`;
+                dt.style.fontWeight = "bold";
+                dt.innerHTML = value.name;
+                addElemToNode(dl_id, dt);
+                createEntries(dt.id, value.entries, 1, run_entry.run, false);
+            });
+        }
+    })
+}
+
 function kernelConfig(diff: boolean) {
-    if (!diff) {
-        diff_data = [];
+    if (got_data) {
+        if (current_diff_status != diff) {
+            current_diff_status = diff;
+            redoKernelConfig(diff);
+        }
+        return;
     }
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -126,6 +208,7 @@ function kernelConfig(diff: boolean) {
             addElemToNode(run_node_id, agg_elem);
             getKernelConfig(value, agg_elem.id, diff);
         })
+        got_data = true;
     }
     http.open("GET", 'visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/perf_stat.ts
+++ b/src/bin/html_files/perf_stat.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { perfStat };
 
+let got_data = false;
+
 function getEvents(run, container_id) {
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -93,6 +95,9 @@ function getEvent(run, key, parent_id) {
 }
 
 function perfStat() {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -123,6 +128,7 @@ function perfStat() {
             addElemToNode(run_node_id, per_value_div);
             getEvents(value, per_value_div.id);
         })
+        got_data = true;
     }
     http.open("GET", '/visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/system_info.ts
+++ b/src/bin/html_files/system_info.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { systemInfo };
 
+let got_data = false;
+
 function getSystemInfo(run, container_id) {
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -27,6 +29,9 @@ function getSystemInfo(run, container_id) {
 }
 
 function systemInfo() {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -57,6 +62,7 @@ function systemInfo() {
             addElemToNode(run_node_id, per_run_div);
             getSystemInfo(value, per_run_div.id);
         })
+        got_data = true;
     }
     http.open("GET", '/visualize/get?get=entries');
     http.send();

--- a/src/bin/html_files/vmstat.ts
+++ b/src/bin/html_files/vmstat.ts
@@ -2,6 +2,8 @@ import './plotly.js';
 import { clearElements, addElemToNode } from './index.js';
 export { vmStat };
 
+let got_data = false;
+
 function getEntries(run, container_id) {
     const http = new XMLHttpRequest();
     http.onload = function () {
@@ -53,6 +55,9 @@ function getEntry(run, key, parent_id) {
 }
 
 function vmStat() {
+    if (got_data) {
+        return;
+    }
     const http = new XMLHttpRequest();
     http.onload = function () {
         var data = JSON.parse(http.response);
@@ -82,6 +87,7 @@ function vmStat() {
             per_value_div.id = `${value}-vmstat-per-data`;
             addElemToNode(run_node_id, per_value_div);
             getEntries(value, per_value_div.id);
+            got_data = true;
         })
     }
     http.open("GET", '/visualize/get?get=entries');


### PR DESCRIPTION
* CPU Utilization aggregate graphs all have y-axis range 0-100.
* All tabs now will now only call the backend server once.
* Show common and different keys for kernel_config and sysctl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
