### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
       - name: Install gcc on Ubuntu
         if: ${{ matrix.distribution == 'Ubuntu' }}
         run: sudo apt install -y build-essential


### PR DESCRIPTION
action-rs/toolchain already includes cargo. Don't use another actions-rs for cargo commands.

action-rs/cargo@v1 has started failing. Since action-rs/toolchain already provides cargo, we are removing the separate action-rs/cargo requirement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
