### PR TITLE
Fix timing calculation for data collection loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ impl PerformanceData {
                 error!("Missed {} interval(s)", ret - 1);
             }
             debug!("Time elapsed: {:?}", start.elapsed());
-            current += time::Duration::from_secs(ret);
+            current += time::Duration::from_secs(ret * self.init_params.interval);
             for (_name, datatype) in self.collectors.iter_mut() {
                 if datatype.is_static {
                     continue;


### PR DESCRIPTION
We need to account for intervals that are not 1s, which the user can change, in the timing calculation when collecting the data.

Before fix:
```
$ ./target/debug/aperf record -r beforefix -p 20 -i 2 -v
[2023-07-31T21:02:14Z INFO  aperf_lib::record] Starting Data collection...
[2023-07-31T21:02:14Z INFO  aperf_lib::record] Preparing data collectors...
[2023-07-31T21:02:14Z ERROR aperf_lib::data::perf_stat] Instance does not expose Perf counters
[2023-07-31T21:02:14Z ERROR aperf_lib] Excluding perf_stat from collection. Error msg: No such file or directory (os error 2)
[2023-07-31T21:02:14Z DEBUG aperf_lib::record] Collecting static data...
[2023-07-31T21:02:14Z INFO  aperf_lib::record] Collecting data...
[2023-07-31T21:02:16Z DEBUG aperf_lib] Time elapsed: 2.000041205s
[2023-07-31T21:02:16Z DEBUG aperf_lib] Collection time: 1.008177583s
[2023-07-31T21:02:18Z DEBUG aperf_lib] Time elapsed: 4.000035925s
[2023-07-31T21:02:18Z DEBUG aperf_lib] Collection time: 2.005990098s
[2023-07-31T21:02:20Z DEBUG aperf_lib] Time elapsed: 6.000044223s
[2023-07-31T21:02:20Z DEBUG aperf_lib] Collection time: 3.006054648s
[2023-07-31T21:02:22Z DEBUG aperf_lib] Time elapsed: 8.000038354s
[2023-07-31T21:02:22Z DEBUG aperf_lib] Collection time: 4.006052694s
[2023-07-31T21:02:24Z DEBUG aperf_lib] Time elapsed: 10.00003887s
[2023-07-31T21:02:24Z DEBUG aperf_lib] Collection time: 5.006054489s
[2023-07-31T21:02:26Z DEBUG aperf_lib] Time elapsed: 12.000032687s
[2023-07-31T21:02:26Z DEBUG aperf_lib] Collection time: 6.006093854s
[2023-07-31T21:02:28Z DEBUG aperf_lib] Time elapsed: 14.000039701s
[2023-07-31T21:02:28Z DEBUG aperf_lib] Collection time: 7.006049833s
[2023-07-31T21:02:30Z DEBUG aperf_lib] Time elapsed: 16.00003478s
[2023-07-31T21:02:30Z DEBUG aperf_lib] Collection time: 8.005977297s
[2023-07-31T21:02:32Z DEBUG aperf_lib] Time elapsed: 18.000035864s
[2023-07-31T21:02:32Z DEBUG aperf_lib] Collection time: 9.005946655s
[2023-07-31T21:02:34Z DEBUG aperf_lib] Time elapsed: 20.000035713s
[2023-07-31T21:02:34Z DEBUG aperf_lib] Collection time: 10.005963793s
[2023-07-31T21:02:36Z DEBUG aperf_lib] Time elapsed: 22.000044147s
[2023-07-31T21:02:36Z DEBUG aperf_lib] Collection time: 11.005997386s
[2023-07-31T21:02:38Z DEBUG aperf_lib] Time elapsed: 24.000029497s
[2023-07-31T21:02:38Z DEBUG aperf_lib] Collection time: 12.005853454s
[2023-07-31T21:02:40Z DEBUG aperf_lib] Time elapsed: 26.00003363s
[2023-07-31T21:02:40Z DEBUG aperf_lib] Collection time: 13.005932322s
[2023-07-31T21:02:42Z DEBUG aperf_lib] Time elapsed: 28.000031519s
[2023-07-31T21:02:42Z DEBUG aperf_lib] Collection time: 14.00586281s
[2023-07-31T21:02:44Z DEBUG aperf_lib] Time elapsed: 30.000030742s
[2023-07-31T21:02:44Z DEBUG aperf_lib] Collection time: 15.005811823s
[2023-07-31T21:02:46Z DEBUG aperf_lib] Time elapsed: 32.000042687s
[2023-07-31T21:02:46Z DEBUG aperf_lib] Collection time: 16.007233728s
[2023-07-31T21:02:48Z DEBUG aperf_lib] Time elapsed: 34.000031382s
[2023-07-31T21:02:48Z DEBUG aperf_lib] Collection time: 17.005924439s
[2023-07-31T21:02:50Z DEBUG aperf_lib] Time elapsed: 36.000036745s
[2023-07-31T21:02:50Z DEBUG aperf_lib] Collection time: 18.005962921s
[2023-07-31T21:02:52Z DEBUG aperf_lib] Time elapsed: 38.000037278s
[2023-07-31T21:02:52Z DEBUG aperf_lib] Collection time: 19.006011066s
[2023-07-31T21:02:54Z DEBUG aperf_lib] Time elapsed: 40.00003664s
[2023-07-31T21:02:54Z DEBUG aperf_lib] Collection time: 20.005954122s
[2023-07-31T21:02:56Z DEBUG aperf_lib] Time elapsed: 42.000033153s
[2023-07-31T21:02:56Z DEBUG aperf_lib] Collection time: 21.005945521s
[2023-07-31T21:02:57Z INFO  aperf_lib] Data collected in beforefix/, archived in beforefix.tar.gz
[2023-07-31T21:02:57Z INFO  aperf_lib::record] Data collection complete.
```

After fix:
```
$ ./target/debug/aperf record -r afterfix -p 20 -i 2 -v
[2023-07-31T20:59:21Z INFO  aperf_lib::record] Starting Data collection...
[2023-07-31T20:59:21Z INFO  aperf_lib::record] Preparing data collectors...
[2023-07-31T20:59:21Z ERROR aperf_lib::data::perf_stat] Instance does not expose Perf counters
[2023-07-31T20:59:21Z ERROR aperf_lib] Excluding perf_stat from collection. Error msg: No such file or directory (os error 2)
[2023-07-31T20:59:21Z DEBUG aperf_lib::record] Collecting static data...
[2023-07-31T20:59:22Z INFO  aperf_lib::record] Collecting data...
[2023-07-31T20:59:24Z DEBUG aperf_lib] Time elapsed: 2.000035697s
[2023-07-31T20:59:24Z DEBUG aperf_lib] Collection time: 7.097897ms
[2023-07-31T20:59:26Z DEBUG aperf_lib] Time elapsed: 4.000043961s
[2023-07-31T20:59:26Z DEBUG aperf_lib] Collection time: 5.987505ms
[2023-07-31T20:59:28Z DEBUG aperf_lib] Time elapsed: 6.000032581s
[2023-07-31T20:59:28Z DEBUG aperf_lib] Collection time: 5.984213ms
[2023-07-31T20:59:30Z DEBUG aperf_lib] Time elapsed: 8.000036612s
[2023-07-31T20:59:30Z DEBUG aperf_lib] Collection time: 5.972965ms
[2023-07-31T20:59:32Z DEBUG aperf_lib] Time elapsed: 10.000037766s
[2023-07-31T20:59:32Z DEBUG aperf_lib] Collection time: 5.947971ms
[2023-07-31T20:59:34Z DEBUG aperf_lib] Time elapsed: 12.000035294s
[2023-07-31T20:59:34Z DEBUG aperf_lib] Collection time: 5.917408ms
[2023-07-31T20:59:36Z DEBUG aperf_lib] Time elapsed: 14.000042425s
[2023-07-31T20:59:36Z DEBUG aperf_lib] Collection time: 5.935722ms
[2023-07-31T20:59:38Z DEBUG aperf_lib] Time elapsed: 16.000031921s
[2023-07-31T20:59:38Z DEBUG aperf_lib] Collection time: 5.88385ms
[2023-07-31T20:59:40Z DEBUG aperf_lib] Time elapsed: 18.000031285s
[2023-07-31T20:59:40Z DEBUG aperf_lib] Collection time: 5.917979ms
[2023-07-31T20:59:42Z DEBUG aperf_lib] Time elapsed: 20.00004061s
[2023-07-31T20:59:42Z DEBUG aperf_lib] Collection time: 5.946473ms
[2023-07-31T20:59:44Z DEBUG aperf_lib] Time elapsed: 22.000037176s
[2023-07-31T20:59:44Z DEBUG aperf_lib] Collection time: 5.900431ms
[2023-07-31T20:59:44Z INFO  aperf_lib] Data collected in afterfix/, archived in afterfix.tar.gz
[2023-07-31T20:59:44Z INFO  aperf_lib::record] Data collection complete.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
