### PR TITLE
Flush buffer after forming archive

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -43,13 +43,15 @@ pub fn form_and_copy_archive(loc: String, report_name: &PathBuf) -> Result<()> {
         /* Create a temp archive */
         let archive_name = format!("{}.tar.gz", &dir_stem);
         let archive_path = format!("{}/{}", APERF_TMP, archive_name);
-        let tar_gz = fs::File::create(&archive_path)?;
-        let enc = GzEncoder::new(tar_gz, Compression::default());
-        let mut tar = tar::Builder::new(enc);
-        tar.append_dir_all(&dir_stem, &loc)?;
+        let archive_dst = report_name.join(format!("data/archive/{}", archive_name));
+        {
+            let tar_gz = fs::File::create(&archive_path)?;
+            let enc = GzEncoder::new(tar_gz, Compression::default());
+            let mut tar = tar::Builder::new(enc);
+            tar.append_dir_all(&dir_stem, &loc)?;
+        }
 
         /* Copy archive to aperf_report */
-        let archive_dst = report_name.join(format!("data/archive/{}", archive_name));
         fs::copy(&archive_path, archive_dst)?;
         return Ok(());
     }


### PR DESCRIPTION
Data remains in the GzEncoder. Ensure it is flushed before performing any other operations on the tarball.

This fixes a bug in the report generation, where the tarball of the raw data is copied to data/archive/. When trying to untar the file, the data is corrupted and un-useable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[aperf_report_works.tar.gz](https://github.com/aws/aperf/files/12337012/aperf_report_works.tar.gz)
[aperf_report_worksnt.tar.gz](https://github.com/aws/aperf/files/12337014/aperf_report_worksnt.tar.gz)
