### PR TITLE
Report: Refactor code, use CSS grid layout

### DIFF
--- a/src/html_files/cpu_utilization.ts
+++ b/src/html_files/cpu_utilization.ts
@@ -137,14 +137,8 @@ function cpuUtilization() {
     if (got_cpu_util_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('cpu-util-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -162,11 +156,6 @@ function cpuUtilization() {
                 this_run_data = cpu_utilization_raw_data['runs'][i];
                 let aggregate_data = this_run_data['key_values']['aggregate'];
                 getCpuUtilization(agg_elem, value, aggregate_data);
-                //Run name
-                var h3_run_per_cpu = document.createElement('h3');
-                h3_run_per_cpu.innerHTML = `${value} - Per CPU Stat`;
-                h3_run_per_cpu.style.textAlign = "center";
-                addElemToNode(run_node_id, h3_run_per_cpu);
                 // Show per type data
                 var per_type_div = document.createElement('div');
                 per_type_div.id = `${value}-cpu-per-type`;

--- a/src/html_files/disk_stats.ts
+++ b/src/html_files/disk_stats.ts
@@ -58,15 +58,9 @@ function diskStats(hide: boolean) {
         return;
     }
     diskstat_hide_zero_na_graphs = hide;
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('disk-stat-runs');
     form_graph_limits(disk_stats_raw_data);
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -75,12 +69,6 @@ function diskStats(hide: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('disk-stat-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');

--- a/src/html_files/flamegraphs.ts
+++ b/src/html_files/flamegraphs.ts
@@ -12,14 +12,8 @@ function flamegraphs() {
     if (got_flamegraphs_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('flamegraphs-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -28,12 +22,6 @@ function flamegraphs() {
         run_div.style.width = `${run_width}%`;
         addElemToNode('flamegraphs-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_run_div = document.createElement('div');

--- a/src/html_files/index.css
+++ b/src/html_files/index.css
@@ -1,14 +1,20 @@
 * {box-sizing: border-box}
-body {font-family: "Lato", sans-serif;}
+body {
+  overflow-y: scroll;
+  font-family: "Lato", sans-serif;
+  display: grid;
+  grid-template-columns: 10% 1fr;
+  grid-column-gap: 1px;
+}
 
 /* Style the tab */
 .tab {
-  float: left;
+  grid-column: 1;
   border: 1px solid #ccc;
   background-color: #f1f1f1;
-  width: 10%;
-  height: 100%;
-  position: fixed;
+  position: sticky;
+  align-self: start;
+  top: 0;
 }
 
 .aperf {
@@ -16,9 +22,18 @@ body {font-family: "Lato", sans-serif;}
   text-align: center;
   color: black;
   padding: 5%;
-  width: 100%;
   font-size: 27px;
+}
+
+.extra {
+  padding: 5px 12px;
+}
+
+.content {
+  grid-column: 2;
   display: grid;
+  grid-template-rows: auto 1fr;
+  grid-row-gap: 1px;
 }
 
 /* Style the buttons inside the tab */
@@ -36,6 +51,13 @@ body {font-family: "Lato", sans-serif;}
   font-size: 17px;
 }
 
+.all-runs {
+  grid-row: 1;
+  position: sticky;
+  z-index: 2;
+  top: 0;
+}
+
 /* Change background color of buttons on hover */
 .tab button:hover {
   background-color: #ddd;
@@ -48,9 +70,8 @@ body {font-family: "Lato", sans-serif;}
 
 /* Style the tab content */
 .tabcontent {
-  float: right;
-  padding: 0px 12px;
+  grid-row: 2;
   border: 1px solid #ccc;
-  width: 90%;
+  width: 100%;
   height: 100%;
 }

--- a/src/html_files/index.html
+++ b/src/html_files/index.html
@@ -23,74 +23,77 @@
 			<button class="tablinks" name="disk_stats">Disk Stats</button>
 			<button class="tablinks" name="netstat">Net Stats</button>
 		</div>
-		<div id="system_info" class="tabcontent">
-			<div id="system-info-runs"></div>
-		</div>
-		<div id="cpu_utilization" class="tabcontent">
-			<div id="cpu-util-runs"></div>
-		</div>
-		<div id="flamegraphs" class="tabcontent">
-			<div id="flamegraphs-runs"></div>
-		</div>
-		<div id="top_functions" class="tabcontent">
-			<div id="top-functions-runs"></div>
-		</div>
-		<div id="processes" class="tabcontent">
-			<div id="processes-runs"></div>
-		</div>
-		<div id="perfstat" class="tabcontent">
-			<div id="perfstat-runs"></div>
-		</div>
-		<div id="meminfo" class="tabcontent">
-			<div>
-				<h3>Hide N/A and all-zero graphs:</h3>
-				<input type="radio" class="meminfo-button" id="meminfo_hide_yes" name="meminfoHide" checked>Yes</button>
-				<input type="radio" class="meminfo-button" id="meminfo_hide_no" name="meminfoHide">No</button>
+		<div class="content">
+			<div id="header" class="all-runs"></div>
+			<div id="system_info" class="tabcontent extra">
+				<div id="system-info-runs"></div>
 			</div>
-			<div id="meminfo-runs"></div>
-		</div>
-		<div id="kernel_config" class="tabcontent">
-			<div>
-				<h3>Diff:</h3>
-				<input type="radio" class="kernel-button" id="kernel_diff_yes" name="kernelDiff" checked>Yes</button>
-				<input type="radio" class="kernel-button" id="kernel_diff_no" name="kernelDiff">No</button>
+			<div id="cpu_utilization" class="tabcontent">
+				<div id="cpu-util-runs"></div>
 			</div>
-			<div id="kernel-config-runs"></div>
-		</div>
-		<div id="sysctl" class="tabcontent">
-			<div>
-				<h3>Diff:</h3>
-				<input type="radio" class="sysctl-button" id="sysctl_diff_yes" name="sysctlDiff" checked>Yes</button>
-				<input type="radio" class="sysctl-button" id="sysctl_diff_no" name="sysctlDiff">No</button>
+			<div id="flamegraphs" class="tabcontent">
+				<div id="flamegraphs-runs"></div>
 			</div>
-			<div id="sysctl-data-runs"></div>
-		</div>
-		<div id="vmstat" class="tabcontent">
-			<div>
-				<h3>Hide N/A and all-zero graphs:</h3>
-				<input type="radio" class="vmstat-button" id="vmstat_hide_yes" name="vmstatHide" checked>Yes</button>
-				<input type="radio" class="vmstat-button" id="vmstat_hide_no" name="vmstatHide">No</button>
+			<div id="top_functions" class="tabcontent extra">
+				<div id="top-functions-runs"></div>
 			</div>
-			<div id="vmstat-runs"></div>
-		</div>
-		<div id="interrupts" class="tabcontent">
-			<div id="interrupt-runs"></div>
-		</div>
-		<div id="disk_stats" class="tabcontent">
-			<div>
-				<h3>Hide N/A and all-zero graphs:</h3>
-				<input type="radio" class="diskstat-button" id="diskstat_hide_yes" name="diskstatHide" checked>Yes</button>
-				<input type="radio" class="diskstat-button" id="diskstat_hide_no" name="diskstatHide">No</button>
+			<div id="processes" class="tabcontent">
+				<div id="processes-runs"></div>
 			</div>
-			<div id="disk-stat-runs"></div>
-		</div>
-		<div id="netstat" class="tabcontent">
-			<div>
-				<h3>Hide N/A and all-zero graphs:</h3>
-				<input type="radio" class="netstat-button" id="netstat_hide_yes" name="netstatHide" checked>Yes</button>
-				<input type="radio" class="netstat-button" id="netstat_hide_no" name="netstatHide">No</button>
+			<div id="perfstat" class="tabcontent">
+				<div id="perfstat-runs"></div>
 			</div>
-			<div id="netstat-runs"></div>
+			<div id="meminfo" class="tabcontent">
+				<div class="extra">
+					<h3>Hide N/A and all-zero graphs:</h3>
+					<input type="radio" class="meminfo-button" id="meminfo_hide_yes" name="meminfoHide" checked>Yes</button>
+					<input type="radio" class="meminfo-button" id="meminfo_hide_no" name="meminfoHide">No</button>
+				</div>
+				<div id="meminfo-runs"></div>
+			</div>
+			<div id="kernel_config" class="tabcontent">
+				<div class=extra>
+					<h3>Diff:</h3>
+					<input type="radio" class="kernel-button" id="kernel_diff_yes" name="kernelDiff" checked>Yes</button>
+					<input type="radio" class="kernel-button" id="kernel_diff_no" name="kernelDiff">No</button>
+				</div>
+				<div id="kernel-config-runs"></div>
+			</div>
+			<div id="sysctl" class="tabcontent">
+				<div class=extra>
+					<h3>Diff:</h3>
+					<input type="radio" class="sysctl-button" id="sysctl_diff_yes" name="sysctlDiff" checked>Yes</button>
+					<input type="radio" class="sysctl-button" id="sysctl_diff_no" name="sysctlDiff">No</button>
+				</div>
+				<div id="sysctl-data-runs"></div>
+			</div>
+			<div id="vmstat" class="tabcontent">
+				<div class=extra>
+					<h3>Hide N/A and all-zero graphs:</h3>
+					<input type="radio" class="vmstat-button" id="vmstat_hide_yes" name="vmstatHide" checked>Yes</button>
+					<input type="radio" class="vmstat-button" id="vmstat_hide_no" name="vmstatHide">No</button>
+				</div>
+				<div id="vmstat-runs"></div>
+			</div>
+			<div id="interrupts" class="tabcontent">
+				<div id="interrupt-runs"></div>
+			</div>
+			<div id="disk_stats" class="tabcontent">
+				<div class=extra>
+					<h3>Hide N/A and all-zero graphs:</h3>
+					<input type="radio" class="diskstat-button" id="diskstat_hide_yes" name="diskstatHide" checked>Yes</button>
+					<input type="radio" class="diskstat-button" id="diskstat_hide_no" name="diskstatHide">No</button>
+				</div>
+				<div id="disk-stat-runs"></div>
+			</div>
+			<div id="netstat" class="tabcontent">
+				<div class=extra>
+					<h3>Hide N/A and all-zero graphs:</h3>
+					<input type="radio" class="netstat-button" id="netstat_hide_yes" name="netstatHide" checked>Yes</button>
+					<input type="radio" class="netstat-button" id="netstat_hide_no" name="netstatHide">No</button>
+				</div>
+				<div id="netstat-runs"></div>
+			</div>
 		</div>
 		<script type="text/javascript" src="data/js/runs.js"></script>
 		<script type="text/javascript" src="data/js/system_info.js"></script>

--- a/src/html_files/index.ts
+++ b/src/html_files/index.ts
@@ -98,5 +98,37 @@ DataTypes.forEach((datatype: DataType, key: string) => {
 		})
 	}
 });
+
+var run_width = 100;
+var float_style = "none";
+
+function create_runs_header() {
+	var data = runs_raw;
+	float_style = "none";
+	if (data.length > 1) {
+		float_style = "left";
+	}
+	run_width = 100 / data.length;
+	data.forEach(function(value, index, arr) {
+		var run_div = document.createElement('div');
+		run_div.id = value;
+		run_div.style.float = float_style;
+		run_div.style.width = `${run_width}%`;
+		run_div.style.border = "1px solid black";
+		run_div.style.background = "lightgray";
+		run_div.style.opacity = "0.95";
+		addElemToNode('header', run_div);
+		var run_node_id = run_div.id;
+
+		var h3_run_name = document.createElement('h3');
+		h3_run_name.innerHTML = value;
+		h3_run_name.style.textAlign = "center";
+		addElemToNode(run_node_id, h3_run_name);
+	});
+}
+
+// Set Runs header
+create_runs_header();
+
 // Show landing page
 document.getElementById("default").click();

--- a/src/html_files/interrupts.ts
+++ b/src/html_files/interrupts.ts
@@ -59,14 +59,8 @@ function interrupts() {
     if (got_interrupt_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('interrupt-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -75,13 +69,6 @@ function interrupts() {
         run_div.style.width = `${run_width}%`;
         addElemToNode('interrupt-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
-
         // Show data
         var per_value_div = document.createElement('div');
         per_value_div.id = `${value}-interrupt-per-data`;

--- a/src/html_files/kernel_config.ts
+++ b/src/html_files/kernel_config.ts
@@ -59,6 +59,7 @@ function kernelConfigNoDiff(run, container_id) {
     let data = JSON.parse(run_entry.raw_entries['key_values']['values']);
     var dl = document.createElement('dl');
     dl.id = `${run}-dl-kernel-config`;
+    dl.classList.add("extra");
     dl.style.float = "none";
     var dl_id = dl.id;
     addElemToNode(container_id, dl);
@@ -75,6 +76,7 @@ function kernelConfigNoDiff(run, container_id) {
 function kernelConfigDiff(value, container_id) {
     var dl = document.createElement('dl');
     dl.id = `${value}-dl-kernel-config`;
+    dl.classList.add("extra");
     dl.style.float = "none";
     var dl_id = dl.id;
     addElemToNode(container_id, dl);
@@ -118,11 +120,6 @@ function kernelConfig(diff: boolean) {
         })
         split_keys(kernel_config_runs, kernel_config_common_keys);
     }
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('kernel-config-runs');
     data.forEach(function (value, index, arr) {
         // Run div
@@ -132,12 +129,6 @@ function kernelConfig(diff: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('kernel-config-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = `${value}`;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         //Show aggregate data
         var agg_elem = document.createElement('div');

--- a/src/html_files/meminfo.ts
+++ b/src/html_files/meminfo.ts
@@ -71,6 +71,7 @@ function getMeminfo(elem, key, run_data) {
         key.includes("Vmalloc Total") ||
         key.includes("Hugepagesize")) {
         var mem_elem = document.createElement('h3');
+        mem_elem.classList.add("extra");
         if (divisor == 1) {
             mem_elem.innerHTML = `${key}: ${y_data[0]}KB`;
         } else {
@@ -122,16 +123,10 @@ function meminfo(hide: boolean) {
         return;
     }
     meminfo_hide_zero_na_graphs = hide;
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('meminfo-runs');
     form_meminfo_averages();
     form_graph_limits(meminfo_raw_data);
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -140,12 +135,6 @@ function meminfo(hide: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('meminfo-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');

--- a/src/html_files/netstat.ts
+++ b/src/html_files/netstat.ts
@@ -45,15 +45,9 @@ function netStat(hide: boolean) {
         return;
     }
     netstat_hide_zero_na_graphs = hide;
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('netstat-runs');
     form_graph_limits(netstat_raw_data);
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -62,12 +56,6 @@ function netStat(hide: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('netstat-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');

--- a/src/html_files/perf_profile.ts
+++ b/src/html_files/perf_profile.ts
@@ -18,14 +18,8 @@ function topFunctions() {
     if (got_top_functions_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('top-functions-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -34,12 +28,6 @@ function topFunctions() {
         run_div.style.width = `${run_width}%`;
         addElemToNode('top-functions-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_run_div = document.createElement('div');

--- a/src/html_files/perf_stat.ts
+++ b/src/html_files/perf_stat.ts
@@ -83,15 +83,9 @@ function perfStat() {
     if (got_perf_stat_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('perfstat-runs');
     form_graph_limits(perf_stat_raw_data);
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -101,12 +95,6 @@ function perfStat() {
         run_div.style.width = `${run_width}%`;
         addElemToNode('perfstat-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');

--- a/src/html_files/processes.ts
+++ b/src/html_files/processes.ts
@@ -46,27 +46,15 @@ function processes() {
     if (got_process_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('processes-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         var run_div = document.createElement('div');
         let this_run_data;
         run_div.id = `${value}-processes`;
         run_div.style.float = float_style;
         run_div.style.width = `${run_width}%`;
         addElemToNode('processes-runs', run_div);
-
         var run_node_id = run_div.id;
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');

--- a/src/html_files/sysctl.ts
+++ b/src/html_files/sysctl.ts
@@ -24,6 +24,7 @@ function form_sysctl_data(run, run_data) {
 function sysctlNoDiff(run, container_id) {
     var dl = document.createElement('dl');
     dl.id = `${run}-dl-sysctl-data`;
+    dl.classList.add("extra");
     dl.style.float = "none";
     var dl_id = dl.id;
     addElemToNode(container_id, dl);
@@ -38,6 +39,7 @@ function sysctlDiff(value) {
     clearElements(agg_id);
     var dl = document.createElement('dl');
     dl.id = `${value}-dl-sysctl-data`;
+    dl.classList.add("extra");
     dl.style.float = "none";
     var dl_id = dl.id;
     addElemToNode(agg_id, dl);
@@ -82,11 +84,6 @@ function sysctl(diff: boolean) {
         split_keys(sysctl_runs, sysctl_common_keys);
     }
 
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('sysctl-data-runs');
     data.forEach(function (value, index, arr) {
         // Run div
@@ -96,12 +93,6 @@ function sysctl(diff: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('sysctl-data-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = `${value}`;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         //Show aggregate data
         var agg_elem = document.createElement('div');

--- a/src/html_files/system_info.ts
+++ b/src/html_files/system_info.ts
@@ -23,14 +23,8 @@ function systemInfo() {
     if (got_system_info_data) {
         return;
     }
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('system-info-runs');
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -39,12 +33,6 @@ function systemInfo() {
         run_div.style.width = `${run_width}%`;
         addElemToNode('system-info-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_run_div = document.createElement('div');

--- a/src/html_files/vmstat.ts
+++ b/src/html_files/vmstat.ts
@@ -45,15 +45,9 @@ function vmStat(hide: boolean) {
         return;
     }
     vmstat_hide_zero_na_graphs = hide;
-    var data = runs_raw;
-    var float_style = "none";
-    if (data.length > 1) {
-        float_style = "left";
-    }
-    var run_width = 100 / data.length;
     clearElements('vmstat-runs');
     form_graph_limits(vmstat_raw_data);
-    data.forEach(function (value, index, arr) {
+    runs_raw.forEach(function (value, index, arr) {
         // Run div
         var run_div = document.createElement('div');
         let this_run_data;
@@ -62,12 +56,6 @@ function vmStat(hide: boolean) {
         run_div.style.width = `${run_width}%`;
         addElemToNode('vmstat-runs', run_div);
         var run_node_id = run_div.id;
-
-        // Run name
-        var h3_run_name = document.createElement('h3');
-        h3_run_name.innerHTML = value;
-        h3_run_name.style.textAlign = "center";
-        addElemToNode(run_node_id, h3_run_name);
 
         // Show data
         var per_value_div = document.createElement('div');


### PR DESCRIPTION
Move to a Grid layout for the report. Remove code that creates header for each tab. Instead, create a header once and pin it to the top. The headers will also show when scrolling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
