### PR TITLE
chore: bump gitleaks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.16.3
+  rev: v8.18.1
   hooks:
   - id: gitleaks
 - repo: https://github.com/pre-commit/mirrors-eslint


### PR DESCRIPTION
*Description of changes:*

bump gitleaks version:
- https://github.com/gitleaks/gitleaks/releases/tag/v8.18.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
