### PR TITLE
Make -r argument to 'report' required and improve usage message

### DIFF
--- a/src/data/processes.rs
+++ b/src/data/processes.rs
@@ -243,7 +243,7 @@ impl GetData for Processes {
             Data::ProcessesRaw(ref value) => value,
             _ => panic!("Invalid Data type in raw file"),
         };
-        *TICKS_PER_SECOND.lock().unwrap() = raw_value.ticks_per_second as u64;
+        *TICKS_PER_SECOND.lock().unwrap() = raw_value.ticks_per_second;
         let reader = BufReader::new(raw_value.data.as_bytes());
         processes.time = raw_value.time;
         for line in reader.lines() {

--- a/src/report.rs
+++ b/src/report.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 #[derive(Clone, Args, Debug)]
 pub struct Report {
     /// Run data to be visualized. Can be a directory or a tarball.
-    #[clap(short, long, value_parser)]
+    #[clap(short, long, value_parser, required = true, num_args = 1..)]
     run: Vec<String>,
 
     /// Report name.


### PR DESCRIPTION
Before, the ```--help``` message didn't indicate multiple ```-r``` arguments could be supplied to ```report```
```
[ec2-user@ip-10-0-0-129 ~]$ ./aperf report --help
Generate an HTML report based on the data collected

Usage: aperf report [OPTIONS]

Options:
  -r, --run <RUN>    Run data to be visualized. Can be a directory or a tarball
  -n, --name <NAME>  Report name
  -v, --verbose...   Show debug messages. Use -vv for more verbose messages
  -h, --help         Print help
  -V, --version      Print version
```

and moreover, you didn't even have to specify any. Doing so would get you an empty report (not very useful).
```
[ec2-user@ip-10-0-0-129 aperf]$ ./target/debug/aperf report -n foo
[2024-04-08T14:54:05Z INFO  aperf_lib::report] Creating APerf report...
[2024-04-08T14:54:05Z INFO  aperf_lib::report] Generating foo.tar.gz

[ec2-user@ip-10-0-0-129 aperf]$ cat foo/data/js/runs.js
runs_raw = []
```

With this change, the usage message shows the ```...``` and running without any ```-r``` arguments results in an error
```
[ec2-user@ip-10-0-0-129 aperf]$ ./target/debug/aperf report --help
Generate an HTML report based on the data collected

Usage: aperf report [OPTIONS] --run <RUN>...

Options:
  -r, --run <RUN>...  Run data to be visualized. Can be a directory or a tarball
  -n, --name <NAME>   Report name
  -v, --verbose...    Show debug messages. Use -vv for more verbose messages
  -h, --help          Print help
  -V, --version       Print version

[ec2-user@ip-10-0-0-129 aperf]$ ./target/debug/aperf report -n foo
error: the following required arguments were not provided:
  --run <RUN>...

Usage: aperf report --run <RUN>... --name <NAME>

For more information, try '--help'.
```
