### PR TITLE
Wait for 'perf record' to finish

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -139,6 +139,13 @@ impl DataType {
         Ok(())
     }
 
+    pub fn finish_data_collection(&mut self) -> Result<()> {
+        trace!("Finish data collection...");
+        self.data
+            .finish_data_collection(self.collector_params.clone())?;
+        Ok(())
+    }
+
     pub fn after_data_collection(&mut self) -> Result<()> {
         trace!("Running post collection actions...");
         self.data
@@ -202,6 +209,14 @@ macro_rules! data {
                 Ok(())
             }
 
+            fn finish_data_collection(&mut self, params: CollectorParams) -> Result<()> {
+                match self {
+                    $(
+                        Data::$x(ref mut value) => value.finish_data_collection(params)?,
+                    )*
+                }
+                Ok(())
+            }
             fn after_data_collection(&mut self, params: CollectorParams) -> Result<()> {
                 match self {
                     $(
@@ -298,6 +313,10 @@ pub trait CollectData {
         Ok(())
     }
     fn collect_data(&mut self) -> Result<()> {
+        noop!();
+        Ok(())
+    }
+    fn finish_data_collection(&mut self, _params: CollectorParams) -> Result<()> {
         noop!();
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,9 @@ impl PerformanceData {
             debug!("Collection time: {:?}", data_collection_time);
         }
         for (_name, datatype) in self.collectors.iter_mut() {
+            datatype.finish_data_collection()?;
+        }
+        for (_name, datatype) in self.collectors.iter_mut() {
             datatype.after_data_collection()?;
         }
         tfd.set_state(TimerState::Disarmed, SetTimeFlags::Default);


### PR DESCRIPTION
The time taken by perf record after the collection period depends on the time of collection and the system load. On heavily loaded systems, profiling can take longer than the time it takes to go from perf collection to perf inject in the post collection step. To prevent a race condition, add a wait before the perf inject step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
