### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         architecture: [X64, ARM64]
-        distribution: [Ubuntu, AL2]
+        distribution: [Ubuntu]
     runs-on:
       - self-hosted
       - Linux


### PR DESCRIPTION
Github Actions has deprecated Node16. It now uses Node20. AL2 cannot run Node20 due to missing packages (glibc). Remove building, testing on AL2. See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
