### PR TITLE
Move profiling processing to the record step

### DIFF
--- a/src/data/flamegraphs.rs
+++ b/src/data/flamegraphs.rs
@@ -2,20 +2,29 @@ extern crate ctor;
 
 use crate::data::{CollectData, CollectorParams, Data, DataType, ProcessedData};
 use crate::visualizer::{DataVisualizer, GetData, ReportParams};
-use crate::{get_file_name, PERFORMANCE_DATA, VISUALIZATION_DATA};
+use crate::{get_file_name, PDError, PERFORMANCE_DATA, VISUALIZATION_DATA};
 use anyhow::Result;
 use ctor::ctor;
 use inferno::collapse::perf::Folder;
 use inferno::collapse::Collapse;
 use inferno::flamegraph::{self, Options};
-use log::{error, trace};
+use log::{error, info, trace};
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{ErrorKind, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
 pub static FLAMEGRAPHS_FILE_NAME: &str = "flamegraph";
+
+fn write_msg_to_svg(mut file: File, msg: String) -> Result<()> {
+    write!(
+        file,
+        "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" height=\"100%\"><text x=\"0%\" y=\"1%\">{}</text></svg>",
+        msg
+    )?;
+    Ok(())
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FlamegraphRaw {
@@ -31,19 +40,22 @@ impl FlamegraphRaw {
 }
 
 impl CollectData for FlamegraphRaw {
+    fn prepare_data_collector(&mut self, _params: CollectorParams) -> Result<()> {
+        match Command::new("perf").args(["--version"]).output() {
+            Err(e) => Err(PDError::DependencyError(format!("'perf' command failed. {}", e)).into()),
+            _ => Ok(()),
+        }
+    }
+
     fn after_data_collection(&mut self, params: CollectorParams) -> Result<()> {
-        let data_dir = PathBuf::from(params.data_dir.clone());
+        let data_dir = PathBuf::from(&params.data_dir);
 
-        let mut file_pathbuf = data_dir.clone();
-        file_pathbuf.push(get_file_name(
-            params.data_dir.clone(),
-            "perf_profile".to_string(),
-        )?);
+        let file_pathbuf =
+            data_dir.join(get_file_name(params.data_dir, "perf_profile".to_string())?);
 
-        let mut perf_jit_loc = data_dir.clone();
-        perf_jit_loc.push(format!("{}-perf.data.jit", params.run_name));
+        let perf_jit_loc = data_dir.join("perf.data.jit");
 
-        println!("Running Perf inject...");
+        trace!("Running Perf inject...");
         let out_jit = Command::new("perf")
             .args([
                 "inject",
@@ -51,19 +63,44 @@ impl CollectData for FlamegraphRaw {
                 "-i",
                 &file_pathbuf.to_str().unwrap(),
                 "-o",
-                perf_jit_loc.clone().to_str().unwrap(),
+                perf_jit_loc.to_str().unwrap(),
             ])
             .status();
+
+        let fg_out = File::create(data_dir.join(format!("{}-flamegraph.svg", params.run_name)))?;
+
         match out_jit {
             Err(e) => {
-                if e.kind() == ErrorKind::NotFound {
-                    error!("'perf' command not found.");
-                } else {
-                    error!("Unknown error: {}", e);
-                }
-                error!("Skip processing profiling data.");
+                let out = format!("Skip processing profiling data due to: {}", e);
+                error!("{}", out);
+                write_msg_to_svg(fg_out, out)?;
             }
-            Ok(_) => trace!("Perf inject successful."),
+            Ok(_) => {
+                info!("Creating flamegraph...");
+                let script_loc = data_dir.join("script.out");
+                let out = Command::new("perf")
+                    .stdout(File::create(&script_loc)?)
+                    .args(["script", "-f", "-i", perf_jit_loc.to_str().unwrap()])
+                    .output();
+                match out {
+                    Err(e) => {
+                        let out = format!("Did not process profiling data due to: {}", e);
+                        error!("{}", out);
+                        write_msg_to_svg(fg_out, out)?;
+                    }
+                    Ok(_) => {
+                        let collapse_loc = data_dir.join("collapse.out");
+
+                        Folder::default()
+                            .collapse_file(Some(script_loc), File::create(&collapse_loc)?)?;
+                        flamegraph::from_files(
+                            &mut Options::default(),
+                            &[collapse_loc.to_path_buf()],
+                            fg_out,
+                        )?;
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -84,68 +121,25 @@ impl Flamegraph {
 
 impl GetData for Flamegraph {
     fn custom_raw_data_parser(&mut self, params: ReportParams) -> Result<Vec<ProcessedData>> {
-        /* Get the perf_profile file */
-        let mut file_pathbuf = PathBuf::from(params.data_dir.clone());
-        file_pathbuf.push(get_file_name(
-            params.data_dir.clone(),
-            "perf_profile".to_string(),
-        )?);
+        let processed_data = vec![ProcessedData::Flamegraph(Flamegraph::new())];
 
-        let _file_name = file_pathbuf.to_str().unwrap();
-        let profile = Flamegraph::new();
+        let file_name = format!("{}-flamegraph.svg", params.run_name);
+        let fg_loc = params.data_dir.join(&file_name);
+        let fg_out = params.report_dir.join("data/js/".to_owned() + &file_name);
 
-        let mut perf_jit_loc = PathBuf::from(params.data_dir.clone());
-        perf_jit_loc.push(format!("{}-perf.data.jit", params.run_name));
-
-        /* Use APERF_TMP to generate intermediate perf files */
-        let tmp_path = PathBuf::from(params.tmp_dir);
-
-        let mut script_loc = tmp_path.clone();
-        script_loc.push(format!("{}-script.out", params.run_name));
-
-        let mut collapse_loc = tmp_path.clone();
-        collapse_loc.push(format!("{}-collapse.out", params.run_name));
-
-        let mut fg_loc = params.report_dir.clone();
-        fg_loc.push(format!("data/js/{}-flamegraph.svg", params.run_name));
-
-        let mut script_out = File::create(script_loc.clone())?;
-        let collapse_out = File::create(collapse_loc.clone())?;
-        let mut fg_out = File::create(fg_loc.clone())?;
-
-        if perf_jit_loc.exists() {
-            let out = Command::new("perf")
-                .args(["script", "-f", "-i", perf_jit_loc.to_str().unwrap()])
-                .output();
-            match out {
-                Err(e) => {
-                    if e.kind() == ErrorKind::NotFound {
-                        error!("'perf' command not found.");
-                    } else {
-                        error!("Unknown error: {}", e);
-                    }
-                    error!("Skip processing profiling data.");
-                    write!(fg_out, "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" height=\"100%\"><text x=\"0%\" y=\"1%\">Did not process profiling data</text></svg>")?;
-                }
-                Ok(v) => {
-                    write!(script_out, "{}", std::str::from_utf8(&v.stdout)?)?;
-                    Folder::default().collapse_file(Some(script_loc), collapse_out)?;
-                    fg_out = std::fs::OpenOptions::new()
-                        .read(true)
-                        .write(true)
-                        .truncate(true)
-                        .open(fg_loc)?;
-                    flamegraph::from_files(
-                        &mut Options::default(),
-                        &[collapse_loc.to_path_buf()],
-                        fg_out,
-                    )?;
-                }
-            }
+        /* Copy the flamegraph to the report dir */
+        if fg_loc.exists() {
+            std::fs::copy(fg_loc, fg_out)?;
         } else {
-            write!(fg_out, "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" height=\"100%\"><text x=\"0%\" y=\"1%\">No data collected</text></svg>")?;
+            write_msg_to_svg(
+                std::fs::OpenOptions::new()
+                    .create_new(true)
+                    .read(true)
+                    .write(true)
+                    .open(fg_out)?,
+                "No data collected".to_string(),
+            )?;
         }
-        let processed_data = vec![ProcessedData::Flamegraph(profile)];
         Ok(processed_data)
     }
 

--- a/src/data/java_profile.rs
+++ b/src/data/java_profile.rs
@@ -25,6 +25,12 @@ pub struct JavaProfileRaw {
     process_map: HashMap<String, Vec<String>>,
 }
 
+impl Default for JavaProfileRaw {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl JavaProfileRaw {
     pub fn new() -> Self {
         JavaProfileRaw {
@@ -51,7 +57,7 @@ impl JavaProfileRaw {
                 Err(e) => {
                     return Err(PDError::DependencyError(format!(
                         "'asprof' command failed. {}",
-                        e.to_string()
+                        e
                     ))
                     .into());
                 }
@@ -105,7 +111,7 @@ impl JavaProfileRaw {
             }
             Err(e) => Err(PDError::DependencyError(format!(
                 "Jps command failed. {}",
-                e.to_string()
+                e
             ))),
         }
     }
@@ -122,7 +128,7 @@ impl JavaProfileRaw {
             }
             Err(e) => Err(PDError::DependencyError(format!(
                 "pgrep command failed. {}",
-                e.to_string()
+                e
             ))),
         }
     }
@@ -233,15 +239,22 @@ impl JavaProfile {
     }
 }
 
+impl Default for JavaProfile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GetData for JavaProfile {
     fn custom_raw_data_parser(
         &mut self,
         params: crate::visualizer::ReportParams,
     ) -> Result<Vec<ProcessedData>> {
-        let mut processes_loc = PathBuf::from(params.data_dir.clone());
-        processes_loc.push(format!("{}-jps-map.json", params.run_name));
+        let processes_loc = params
+            .data_dir
+            .join(format!("{}-jps-map.json", params.run_name));
         let processes_json =
-            fs::read_to_string(processes_loc.to_str().unwrap()).unwrap_or(String::new());
+            fs::read_to_string(processes_loc.to_str().unwrap()).unwrap_or_default();
         let mut process_map: HashMap<String, Vec<String>> =
             serde_json::from_str(&processes_json).unwrap_or(HashMap::new());
         let process_list: Vec<String> = process_map.clone().into_keys().collect();
@@ -252,7 +265,7 @@ impl GetData for JavaProfile {
                 "data/js/{}-java-flamegraph-{}.html",
                 params.run_name, process
             ));
-            let mut html_loc = PathBuf::from(params.data_dir.clone());
+            let mut html_loc = params.data_dir.clone();
             html_loc.push(format!(
                 "{}-java-flamegraph-{}.html",
                 params.run_name, process

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -9,8 +9,8 @@ use std::{collections::HashMap, fs::File};
 
 #[derive(Clone, Debug)]
 pub struct ReportParams {
-    pub data_dir: String,
-    pub tmp_dir: String,
+    pub data_dir: PathBuf,
+    pub tmp_dir: PathBuf,
     pub report_dir: PathBuf,
     pub run_name: String,
     pub data_file_path: PathBuf,
@@ -19,8 +19,8 @@ pub struct ReportParams {
 impl ReportParams {
     fn new() -> Self {
         ReportParams {
-            data_dir: String::new(),
-            tmp_dir: String::new(),
+            data_dir: PathBuf::new(),
+            tmp_dir: PathBuf::new(),
             report_dir: PathBuf::new(),
             run_name: String::new(),
             data_file_path: PathBuf::new(),
@@ -76,8 +76,8 @@ impl DataVisualizer {
     ) -> Result<()> {
         let file = get_file(dir.clone(), self.file_name.clone())?;
         let full_path = Path::new("/proc/self/fd").join(file.as_raw_fd().to_string());
-        self.report_params.data_dir = dir.clone();
-        self.report_params.tmp_dir = tmp_dir;
+        self.report_params.data_dir = PathBuf::from(dir.clone());
+        self.report_params.tmp_dir = PathBuf::from(tmp_dir);
         self.report_params.report_dir = fin_dir;
         self.report_params.run_name = name.clone();
         self.report_params.data_file_path = fs::read_link(full_path).unwrap();


### PR DESCRIPTION
Currently, users are unable to generate reports, of an aperf run with --profile, on a system that is not the SUT. Move the processing step for perf_profile and flamegraph to the record stage.

Testing:
Prior to this change, it was not possible to generate a comparison of profiling between runs in arm64 and x86.

[arm64profile.tar.gz](https://github.com/user-attachments/files/16275219/arm64profile.tar.gz)
[x86profile.tar.gz](https://github.com/user-attachments/files/16275220/x86profile.tar.gz)
[profilecmp.tar.gz](https://github.com/user-attachments/files/16275221/profilecmp.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
