### PR TITLE
Add support for catching signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "nix",
  "perf-event2",
  "procfs",
  "rustix 0.38.28",
@@ -550,6 +551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,33 +832,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1212,12 +1198,6 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
-
-[[package]]
-name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
@@ -1234,7 +1214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
- "io-lifetimes 1.0.10",
+ "io-lifetimes",
  "rustix 0.37.18",
  "windows-sys 0.48.0",
 ]
@@ -1262,9 +1242,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "link-cplusplus"
@@ -1274,12 +1254,6 @@ checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1352,6 +1326,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1695,27 +1681,13 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.34.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2079c267b8394eb529872c3cf92e181c378b41fea36e68130357b52493701d2e"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.2.8",
- "io-lifetimes 0.6.1",
- "libc",
- "linux-raw-sys 0.0.46",
- "winapi",
-]
-
-[[package]]
-name = "rustix"
 version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.8",
- "io-lifetimes 1.0.10",
+ "errno",
+ "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.6",
  "windows-sys 0.48.0",
@@ -1728,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.0",
- "errno 0.3.8",
+ "errno",
  "libc",
  "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
@@ -2177,11 +2149,11 @@ dependencies = [
 
 [[package]]
 name = "timerfd"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f85a7c965b8e7136952f59f2a359694c78f105b2d2ff99cf6c2c404bf7e33f"
+checksum = "84e482e368cf7efa2c8b570f476e5b9fd9fd5e9b9219fc567832b05f13511091"
 dependencies = [
- "rustix 0.34.8",
+ "rustix 0.38.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ name = "aperf"
 path = "src/bin/aperf.rs"
 
 [dependencies]
+nix = { version = "0.29.0", features = ["signal", "poll"] }
 clap = { version = "4.2.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
@@ -29,7 +30,7 @@ thiserror = "1.0"
 log = "0.4.21"
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
-timerfd = "1.3.0"
+timerfd = "1.6.0"
 procfs = "0.12.0"
 ctor = "0.2.6"
 sysinfo = "0.26.2"

--- a/src/data.rs
+++ b/src/data.rs
@@ -39,6 +39,7 @@ use kernel_config::KernelConfig;
 use log::trace;
 use meminfodata::{MeminfoData, MeminfoDataRaw};
 use netstat::{Netstat, NetstatRaw};
+use nix::sys::{signal, signal::Signal};
 use perf_profile::{PerfProfile, PerfProfileRaw};
 use perf_stat::{PerfStat, PerfStatRaw};
 use processes::{Processes, ProcessesRaw};
@@ -60,6 +61,7 @@ pub struct CollectorParams {
     pub run_name: String,
     pub profile: HashMap<String, String>,
     pub tmp_dir: PathBuf,
+    pub signal: Signal,
 }
 
 impl CollectorParams {
@@ -72,6 +74,7 @@ impl CollectorParams {
             run_name: String::new(),
             profile: HashMap::new(),
             tmp_dir: PathBuf::new(),
+            signal: signal::SIGTERM,
         }
     }
 }
@@ -107,6 +110,10 @@ impl DataType {
 
     pub fn is_profile_option(&mut self) {
         self.is_profile_option = true;
+    }
+
+    pub fn set_signal(&mut self, signal: Signal) {
+        self.collector_params.signal = signal;
     }
 
     pub fn init_data_type(&mut self, param: InitParams) -> Result<()> {

--- a/src/data/perf_profile.rs
+++ b/src/data/perf_profile.rs
@@ -6,6 +6,7 @@ use crate::{PDError, PERFORMANCE_DATA, VISUALIZATION_DATA};
 use anyhow::Result;
 use ctor::ctor;
 use log::{error, trace};
+use nix::{sys::signal, unistd::Pid};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
@@ -78,6 +79,11 @@ impl CollectData for PerfProfileRaw {
             None => return Ok(()),
             Some(_) => {}
         }
+
+        signal::kill(
+            Pid::from_raw(child.as_mut().unwrap().id() as i32),
+            params.signal,
+        )?;
 
         trace!("Waiting for perf profile collection to complete...");
         match child.as_mut().unwrap().wait() {


### PR DESCRIPTION
This is used if the user ends an Aperf run using Ctrl+c or kill <pid>.

Ran aperf record and ctrl-c'd:
$ ./target/debug/aperf record -r ctrlcrecord
[2024-07-25T15:37:59Z INFO  aperf_lib::record] Starting Data collection...
[2024-07-25T15:37:59Z INFO  aperf_lib::record] Preparing data collectors...
[2024-07-25T15:37:59Z WARN  aperf_lib::data::perf_stat] Instance does not expose Perf counters
[2024-07-25T15:37:59Z ERROR aperf_lib] Excluding perf_stat from collection. Error msg: No such file or directory (os error 2)
[2024-07-25T15:37:59Z INFO  aperf_lib::record] Collecting data...
^C[2024-07-25T15:38:01Z INFO  aperf_lib] Caught SIGINT. Exiting...
[2024-07-25T15:38:02Z INFO  aperf_lib] Data collected in ctrlcrecord/, archived in ctrlcrecord.tar.gz
[2024-07-25T15:38:02Z INFO  aperf_lib::record] Data collection complete.

Ran aperf record and send SIGTERM with kill:
$ ./target/debug/aperf record -r sigtermrecord -p 100
[2024-07-25T15:40:34Z INFO  aperf_lib::record] Starting Data collection...
[2024-07-25T15:40:34Z INFO  aperf_lib::record] Preparing data collectors...
[2024-07-25T15:40:34Z WARN  aperf_lib::data::perf_stat] Instance does not expose Perf counters
[2024-07-25T15:40:34Z ERROR aperf_lib] Excluding perf_stat from collection. Error msg: No such file or directory (os error 2)
[2024-07-25T15:40:35Z INFO  aperf_lib::record] Collecting data...
[2024-07-25T15:40:51Z INFO  aperf_lib] Caught SIGTERM. Exiting...
[2024-07-25T15:40:51Z INFO  aperf_lib] Data collected in sigtermrecord/, archived in sigtermrecord.tar.gz
[2024-07-25T15:40:51Z INFO  aperf_lib::record] Data collection complete.

[ctrlcrecord.tar.gz](https://github.com/user-attachments/files/16380372/ctrlcrecord.tar.gz)
[sigtermrecord.tar.gz](https://github.com/user-attachments/files/16380373/sigtermrecord.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
