### PR TITLE
Add error message for fail to create record temp folder

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -2,8 +2,8 @@ use crate::{data, InitParams, PERFORMANCE_DATA};
 use anyhow::Result;
 use clap::Args;
 use log::{debug, error, info};
-use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::{fs, process};
 
 pub static APERF_TMP: &str = "/tmp/aperf_tmp";
 
@@ -88,7 +88,10 @@ pub fn record(record: &Record) -> Result<()> {
     }
 
     fs::remove_dir_all(APERF_TMP).ok();
-    fs::create_dir(APERF_TMP)?;
+    if let Err(e) = fs::create_dir(APERF_TMP) {
+        error!("Could not create /tmp/aperf_tmp folder.\n{}: Remove using 'sudo rm -rf /tmp/aperf_tmp'.", e);
+        process::exit(1);
+    }
     let mut perms: fs::Permissions = fs::metadata(APERF_TMP)?.permissions();
     perms.set_mode(0o777);
     fs::set_permissions(APERF_TMP, perms)?;


### PR DESCRIPTION
If aperf record is run with sudo and exits without cleaning up its temp folder, future non-sudo aperf records will fail to create this folder and panic. This error message informs the user of the error, and how to remove the existing folder with root permissions.

*Description of changes:*
Added error check and message when aperf record creates the aperf_tmp folder.

Tested with existing tmp folder with different permissions. When aperf is unable to create the folder it displays this error message:
```
[2024-07-26T17:05:38Z ERROR aperf_lib::record] Could not create /tmp/aperf_tmp folder.
    File exists (os error 17): Remove using 'sudo rm -rf /tmp/aperf_tmp'.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
