### PR TITLE
Add AMD PMC/U support

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -10,6 +10,9 @@ cfg_if::cfg_if! {
         pub mod intel_perf_events;
         pub mod intel_icelake_perf_events;
         pub mod intel_sapphire_rapids_perf_events;
+        pub mod amd_perf_events;
+        pub mod amd_genoa_perf_events;
+        pub mod amd_milan_perf_events;
     }
 }
 pub mod interrupts;

--- a/src/data/amd_genoa_perf_events.rs
+++ b/src/data/amd_genoa_perf_events.rs
@@ -1,6 +1,6 @@
 use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
 
-static STALL_BACKEND_PKC: NamedTypeCtr = NamedTypeCtr {
+static STALL_BACKEND: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
     name: "Backend-Stalls",
     config: 0x100001ea0,
@@ -15,7 +15,7 @@ lazy_static! {
     pub static ref GENOA_CTRS: Vec<NamedCtr<'static>> = [
         NamedCtr {
             name: "stall_backend_pkc",
-            nrs: vec![STALL_BACKEND_PKC],
+            nrs: vec![STALL_BACKEND],
             drs: vec![CYCLES],
             scale: 167 //~= 1000/6
         },

--- a/src/data/amd_genoa_perf_events.rs
+++ b/src/data/amd_genoa_perf_events.rs
@@ -1,0 +1,24 @@
+use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
+
+static STALL_BACKEND_PKC: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Backend-Stalls",
+    config: 0x100001ea0,
+};
+static CYCLES: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Cycles",
+    config: 0x0076,
+};
+
+lazy_static! {
+    pub static ref GENOA_CTRS: Vec<NamedCtr<'static>> = [
+        NamedCtr {
+            name: "stall_backend_pkc",
+            nrs: vec![STALL_BACKEND_PKC],
+            drs: vec![CYCLES],
+            scale: 167 //~= 1000/6
+        },
+    ]
+    .to_vec();
+}

--- a/src/data/amd_milan_perf_events.rs
+++ b/src/data/amd_milan_perf_events.rs
@@ -19,17 +19,11 @@ static CYCLES: NamedTypeCtr = NamedTypeCtr {
 lazy_static! {
     pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [
         NamedCtr {
-            name: "stall_backend_pkc1",
-            nrs: vec![STALL_BACKEND_1],
+            name: "stall_backend",
+            nrs: vec![STALL_BACKEND_1, STALL_BACKEND_2],
             drs: vec![CYCLES],
             scale: 1000
-        },
-        NamedCtr {
-            name: "stall_backend_pkc2",
-            nrs: vec![STALL_BACKEND_2],
-            drs: vec![CYCLES],
-            scale: 1000
-        },
+        }
     ]
     .to_vec();
 }

--- a/src/data/amd_milan_perf_events.rs
+++ b/src/data/amd_milan_perf_events.rs
@@ -1,11 +1,11 @@
 use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
 
-static STALL_BACKEND_PKC1: NamedTypeCtr = NamedTypeCtr {
+static STALL_BACKEND_1: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
     name: "Backend-Stalls-1",
     config: 0xf7ae,
 };
-static STALL_BACKEND_PKC2: NamedTypeCtr = NamedTypeCtr {
+static STALL_BACKEND_2: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
     name: "Backend-Stalls-2",
     config: 0x27af,
@@ -20,13 +20,13 @@ lazy_static! {
     pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [
         NamedCtr {
             name: "stall_backend_pkc1",
-            nrs: vec![STALL_BACKEND_PKC1],
+            nrs: vec![STALL_BACKEND_1],
             drs: vec![CYCLES],
             scale: 1000
         },
         NamedCtr {
             name: "stall_backend_pkc2",
-            nrs: vec![STALL_BACKEND_PKC2],
+            nrs: vec![STALL_BACKEND_2],
             drs: vec![CYCLES],
             scale: 1000
         },

--- a/src/data/amd_milan_perf_events.rs
+++ b/src/data/amd_milan_perf_events.rs
@@ -1,0 +1,35 @@
+use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
+
+static STALL_BACKEND_PKC1: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Backend-Stalls-1",
+    config: 0xf7ae,
+};
+static STALL_BACKEND_PKC2: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Backend-Stalls-2",
+    config: 0x27af,
+};
+static CYCLES: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Cycles",
+    config: 0x0076,
+};
+
+lazy_static! {
+    pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [
+        NamedCtr {
+            name: "stall_backend_pkc1",
+            nrs: vec![STALL_BACKEND_PKC1],
+            drs: vec![CYCLES],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "stall_backend_pkc2",
+            nrs: vec![STALL_BACKEND_PKC2],
+            drs: vec![CYCLES],
+            scale: 1000
+        },
+    ]
+    .to_vec();
+}

--- a/src/data/amd_milan_perf_events.rs
+++ b/src/data/amd_milan_perf_events.rs
@@ -18,7 +18,7 @@ static CYCLES: NamedTypeCtr = NamedTypeCtr {
 
 lazy_static! {
     pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [NamedCtr {
-        name: "stall_backend",
+        name: "stall_backend_pkc",
         nrs: vec![STALL_BACKEND_1, STALL_BACKEND_2],
         drs: vec![CYCLES],
         scale: 1000

--- a/src/data/amd_milan_perf_events.rs
+++ b/src/data/amd_milan_perf_events.rs
@@ -17,13 +17,11 @@ static CYCLES: NamedTypeCtr = NamedTypeCtr {
 };
 
 lazy_static! {
-    pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [
-        NamedCtr {
-            name: "stall_backend",
-            nrs: vec![STALL_BACKEND_1, STALL_BACKEND_2],
-            drs: vec![CYCLES],
-            scale: 1000
-        }
-    ]
+    pub static ref MILAN_CTRS: Vec<NamedCtr<'static>> = [NamedCtr {
+        name: "stall_backend",
+        nrs: vec![STALL_BACKEND_1, STALL_BACKEND_2],
+        drs: vec![CYCLES],
+        scale: 1000
+    }]
     .to_vec();
 }

--- a/src/data/amd_perf_events.rs
+++ b/src/data/amd_perf_events.rs
@@ -11,54 +11,55 @@ static CYCLES: NamedTypeCtr = NamedTypeCtr {
     name: "Cycles",
     config: 0x0076,
 };
-static BRANCHES: NamedTypeCtr = NamedTypeCtr {
+static BRANCH_MISPRED: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "Branches",
+    name: "Branch-Mispredictions",
     config: 0x00c3,
 };
-static L1_DATA: NamedTypeCtr = NamedTypeCtr {
+static L1_DATA_FILL: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "L1-Data",
+    name: "L1-Data-Fills",
     config: 0xff44,
 };
-static L1_INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {
+static L1_INSTRUCTION_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "L1-Instructions",
+    name: "L1-Instruction-Misses",
     config: 0x1060,
 };
-static L2: NamedTypeCtr = NamedTypeCtr {
+static L2_DEMAND_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "L2",
+    name: "L2-Demand-Misses",
     config: 0x0964,
 };
-static L3: NamedTypeCtr = NamedTypeCtr {
+static L1_ANY_FILLS_DRAM: NamedTypeCtr = NamedTypeCtr {
+    // Approximately L3 Misses
     perf_type: PerfType::RAW,
-    name: "L3",
-    config: 0x0843,
+    name: "L1-Any-Fills-DRAM",
+    config: 0x0844,
 };
-static STALL_FRONTEND_PKC: NamedTypeCtr = NamedTypeCtr {
+static STALL_FRONTEND: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
     name: "Frontend-Stalls",
     config: 0x00a9,
 };
-static INSTRUCTION_TLB: NamedTypeCtr = NamedTypeCtr {
+static INSTRUCTION_TLB_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "Instruction-TLB",
+    name: "Instruction-TLB-Misses",
     config: 0x0084,
 };
-static INSTRUCTION_TLB_TW: NamedTypeCtr = NamedTypeCtr {
+static INSTRUCTION_TLB_TW_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "Instruction-TLB-TW",
+    name: "Instruction-TLB-TW-Misses",
     config: 0x0f85,
 };
-static DATA_TLB: NamedTypeCtr = NamedTypeCtr {
+static DATA_TLB_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "Data-TLB",
+    name: "Data-TLB-Misses",
     config: 0xff45,
 };
-static DATA_TLB_TW: NamedTypeCtr = NamedTypeCtr {
+static DATA_TLB_TW_MISS: NamedTypeCtr = NamedTypeCtr {
     perf_type: PerfType::RAW,
-    name: "Data-TLB-TW",
+    name: "Data-TLB-TW-Misses",
     config: 0xf045,
 };
 
@@ -72,61 +73,61 @@ lazy_static! {
         },
         NamedCtr {
             name: "branch-mpki",
-            nrs: vec![BRANCHES],
+            nrs: vec![BRANCH_MISPRED],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "data-l1-mpki",
-            nrs: vec![L1_DATA],
+            nrs: vec![L1_DATA_FILL],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "inst-l1-mpki",
-            nrs: vec![L1_INSTRUCTIONS],
+            nrs: vec![L1_INSTRUCTION_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "l2-mpki",
-            nrs: vec![L2],
+            nrs: vec![L2_DEMAND_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "l3-mpki",
-            nrs: vec![L3],
+            nrs: vec![L1_ANY_FILLS_DRAM],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "stall_frontend_pkc",
-            nrs: vec![STALL_FRONTEND_PKC],
+            nrs: vec![STALL_FRONTEND],
             drs: vec![CYCLES],
             scale: 1000
         },
         NamedCtr {
             name: "inst-tlb-mpki",
-            nrs: vec![INSTRUCTION_TLB],
+            nrs: vec![INSTRUCTION_TLB_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "inst-tlb-tw-mpki",
-            nrs: vec![INSTRUCTION_TLB_TW],
+            nrs: vec![INSTRUCTION_TLB_TW_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "data-tlb-mpki",
-            nrs: vec![DATA_TLB],
+            nrs: vec![DATA_TLB_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },
         NamedCtr {
             name: "data-tlb-tw-pki",
-            nrs: vec![DATA_TLB_TW],
+            nrs: vec![DATA_TLB_TW_MISS],
             drs: vec![INSTRUCTIONS],
             scale: 1000
         },

--- a/src/data/amd_perf_events.rs
+++ b/src/data/amd_perf_events.rs
@@ -1,0 +1,135 @@
+use crate::data::perf_stat::{NamedCtr, NamedTypeCtr, PerfType};
+
+// amd events
+static INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Instructions",
+    config: 0x00c0,
+};
+static CYCLES: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Cycles",
+    config: 0x0076,
+};
+static BRANCHES: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Branches",
+    config: 0x00c3,
+};
+static L1_DATA: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "L1-Data",
+    config: 0xff44,
+};
+static L1_INSTRUCTIONS: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "L1-Instructions",
+    config: 0x1060,
+};
+static L2: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "L2",
+    config: 0x0964,
+};
+static L3: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "L3",
+    config: 0x0843,
+};
+static STALL_FRONTEND_PKC: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Frontend-Stalls",
+    config: 0x00a9,
+};
+static INSTRUCTION_TLB: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Instruction-TLB",
+    config: 0x0084,
+};
+static INSTRUCTION_TLB_TW: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Instruction-TLB-TW",
+    config: 0x0f85,
+};
+static DATA_TLB: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Data-TLB",
+    config: 0xff45,
+};
+static DATA_TLB_TW: NamedTypeCtr = NamedTypeCtr {
+    perf_type: PerfType::RAW,
+    name: "Data-TLB-TW",
+    config: 0xf045,
+};
+
+lazy_static! {
+    pub static ref PERF_LIST: Vec<NamedCtr<'static>> = [
+        NamedCtr {
+            name: "ipc",
+            nrs: vec![INSTRUCTIONS],
+            drs: vec![CYCLES],
+            scale: 1
+        },
+        NamedCtr {
+            name: "branch-mpki",
+            nrs: vec![BRANCHES],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "data-l1-mpki",
+            nrs: vec![L1_DATA],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "inst-l1-mpki",
+            nrs: vec![L1_INSTRUCTIONS],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "l2-mpki",
+            nrs: vec![L2],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "l3-mpki",
+            nrs: vec![L3],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "stall_frontend_pkc",
+            nrs: vec![STALL_FRONTEND_PKC],
+            drs: vec![CYCLES],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "inst-tlb-mpki",
+            nrs: vec![INSTRUCTION_TLB],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "inst-tlb-tw-mpki",
+            nrs: vec![INSTRUCTION_TLB_TW],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "data-tlb-mpki",
+            nrs: vec![DATA_TLB],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+        NamedCtr {
+            name: "data-tlb-tw-pki",
+            nrs: vec![DATA_TLB_TW],
+            drs: vec![INSTRUCTIONS],
+            scale: 1000
+        },
+    ]
+    .to_vec();
+}

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -146,9 +146,9 @@ impl CollectData for PerfStatRaw {
                     perf_list = amd_perf_events::PERF_LIST.to_vec();
 
                     /* Get Model specific events */
-                    platform_specific_counter = match cpu_info.model_name.as_str() {
+                    platform_specific_counter = match cpu_info.model_name.get(..13).unwrap_or_default() {
                         "AMD EPYC 9R14" => GENOA_CTRS.to_vec(),
-                        "AMD EPYC 7R13 Processor" => MILAN_CTRS.to_vec(),
+                        "AMD EPYC 7R13" => MILAN_CTRS.to_vec(),
                         _ => Vec::new(),
                     };
                 } else {

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -17,9 +17,10 @@ use std::sync::Mutex;
 use crate::data::grv_perf_events;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use {
-    crate::data::intel_icelake_perf_events::ICX_CTRS, crate::data::intel_perf_events,
-    crate::data::intel_sapphire_rapids_perf_events::SPR_CTRS, crate::data::utils::get_cpu_info,
-    indexmap::IndexMap,
+    crate::data::amd_genoa_perf_events::GENOA_CTRS, crate::data::amd_milan_perf_events::MILAN_CTRS,
+    crate::data::amd_perf_events, crate::data::intel_icelake_perf_events::ICX_CTRS,
+    crate::data::intel_perf_events, crate::data::intel_sapphire_rapids_perf_events::SPR_CTRS,
+    crate::data::utils::get_cpu_info, indexmap::IndexMap,
 };
 
 pub static PERF_STAT_FILE_NAME: &str = "perf_stat";
@@ -138,6 +139,16 @@ impl CollectData for PerfStatRaw {
                     platform_specific_counter = match cpu_info.model_name.as_str() {
                         "Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz" => ICX_CTRS.to_vec(),
                         "Intel(R) Xeon(R) Platinum 8488C" => SPR_CTRS.to_vec(),
+                        _ => Vec::new(),
+                    };
+                } else if cpu_info.vendor == "AuthenticAMD" {
+                    warn!("Event multiplexing may result in bad PMU data."); //TODO: mitigate bad PMU data on AMD instances
+                    perf_list = amd_perf_events::PERF_LIST.to_vec();
+
+                    /* Get Model specific events */
+                    platform_specific_counter = match cpu_info.model_name.as_str() {
+                        "AMD EPYC 9R14" => GENOA_CTRS.to_vec(),
+                        "AMD EPYC 7R13 Processor" => MILAN_CTRS.to_vec(),
                         _ => Vec::new(),
                     };
                 } else {


### PR DESCRIPTION
*Description of changes:*

- Added AMD PMU event numbers and support in `perf_stat`

*Testing:*

Ran benchmarks on AMD milan and genoa family instances and compared output to results generated by [perfrunbook](https://github.com/aws/aws-graviton-getting-started/tree/main/perfrunbook/utilities) and Intel/graviton based instances.
Example of ipc comparison between perfrunbook and aperf:

<img width="1481" alt="Screenshot 2024-08-05 at 11 15 21 PM" src="https://github.com/user-attachments/assets/53cd01b9-1f65-4d8c-a840-40b533178490">
<img width="700" alt="Screenshot 2024-08-05 at 11 34 01 PM" src="https://github.com/user-attachments/assets/a12792d1-541a-47cb-a4d1-e1267e2f07f9">



Note: We observed some incorrect data presumably from event multiplexing (up to 13 groups of 14 events). Values may be different than true counts due to this scaling, but trends remain accurate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.