### PR TITLE
missed changes: copy temp files instead of move, crate use formatting

### DIFF
--- a/src/data/java_profile.rs
+++ b/src/data/java_profile.rs
@@ -230,7 +230,7 @@ impl CollectData for JavaProfileRaw {
                 key
             );
 
-            fs::rename(tmp_loc.clone(), html_loc).ok();
+            fs::copy(tmp_loc.clone(), html_loc).ok();
         }
 
         let mut jps_map = File::create(

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -17,10 +17,12 @@ use std::sync::Mutex;
 use crate::data::grv_perf_events;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use {
-    crate::data::amd_genoa_perf_events::GENOA_CTRS, crate::data::amd_milan_perf_events::MILAN_CTRS,
-    crate::data::amd_perf_events, crate::data::intel_icelake_perf_events::ICX_CTRS,
-    crate::data::intel_perf_events, crate::data::intel_sapphire_rapids_perf_events::SPR_CTRS,
-    crate::data::utils::get_cpu_info, indexmap::IndexMap,
+    crate::data::{
+        amd_genoa_perf_events::GENOA_CTRS, amd_milan_perf_events::MILAN_CTRS, amd_perf_events,
+        intel_icelake_perf_events::ICX_CTRS, intel_perf_events,
+        intel_sapphire_rapids_perf_events::SPR_CTRS, utils::get_cpu_info,
+    },
+    indexmap::IndexMap,
 };
 
 pub static PERF_STAT_FILE_NAME: &str = "perf_stat";


### PR DESCRIPTION
*Description of changes:*

- Java profile now copies instead of moving the flamegraph files from the temp directory to the record directory. This makes aperf the owner of the file.
- Reformatted PMU module imports.


*Testing:*

Ran on AMD instances and checked for perf_stat collecting events. Profiled JVMs and verified ownership matches the user who ran aperf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
