### PR TITLE
Create a tmp directory for record and report

### DIFF
--- a/src/data/flamegraphs.rs
+++ b/src/data/flamegraphs.rs
@@ -40,14 +40,14 @@ impl FlamegraphRaw {
 }
 
 impl CollectData for FlamegraphRaw {
-    fn prepare_data_collector(&mut self, _params: CollectorParams) -> Result<()> {
+    fn prepare_data_collector(&mut self, _params: &CollectorParams) -> Result<()> {
         match Command::new("perf").args(["--version"]).output() {
             Err(e) => Err(PDError::DependencyError(format!("'perf' command failed. {}", e)).into()),
             _ => Ok(()),
         }
     }
 
-    fn after_data_collection(&mut self, params: CollectorParams) -> Result<()> {
+    fn after_data_collection(&mut self, params: &CollectorParams) -> Result<()> {
         let data_dir = PathBuf::from(&params.data_dir);
 
         let file_pathbuf = data_dir.join(get_file_name(

--- a/src/data/java_profile.rs
+++ b/src/data/java_profile.rs
@@ -38,7 +38,7 @@ impl JavaProfileRaw {
         }
     }
 
-    fn launch_asprof(&self, jids: Vec<String>, params: CollectorParams) -> Result<()> {
+    fn launch_asprof(&self, jids: Vec<String>, params: &CollectorParams) -> Result<()> {
         for jid in &jids {
             match Command::new("asprof")
                 .args([
@@ -137,7 +137,7 @@ impl JavaProfileRaw {
 }
 
 impl CollectData for JavaProfileRaw {
-    fn prepare_data_collector(&mut self, params: CollectorParams) -> Result<()> {
+    fn prepare_data_collector(&mut self, params: &CollectorParams) -> Result<()> {
         let mut jids: Vec<String> = Vec::new();
         let pgrep: Vec<String> = self.launch_pgrep()?;
         for pid in pgrep {
@@ -172,7 +172,7 @@ impl CollectData for JavaProfileRaw {
         }
         jids.sort();
         jids.dedup();
-        self.launch_asprof(jids, params.clone())
+        self.launch_asprof(jids, params)
     }
 
     fn collect_data(&mut self, params: &CollectorParams) -> Result<()> {
@@ -198,10 +198,10 @@ impl CollectData for JavaProfileRaw {
         }
 
         self.update_process_map()?;
-        self.launch_asprof(jids, params.clone())
+        self.launch_asprof(jids, params)
     }
 
-    fn finish_data_collection(&mut self, params: CollectorParams) -> Result<()> {
+    fn finish_data_collection(&mut self, params: &CollectorParams) -> Result<()> {
         for child in ASPROF_CHILDREN.lock().unwrap().iter() {
             signal::kill(Pid::from_raw(child.id() as i32), params.signal)?;
         }
@@ -240,10 +240,6 @@ impl CollectData for JavaProfileRaw {
         )?;
         write!(jps_map, "{}", serde_json::to_string(&self.process_map)?)?;
 
-        Ok(())
-    }
-
-    fn after_data_collection(&mut self, _params: CollectorParams) -> Result<()> {
         Ok(())
     }
 }

--- a/src/data/perf_profile.rs
+++ b/src/data/perf_profile.rs
@@ -9,9 +9,11 @@ use log::{error, trace};
 use nix::{sys::signal, unistd::Pid};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
-use std::process::{Child, Command, Stdio};
-use std::sync::Mutex;
+use std::{
+    io::Write,
+    process::{Child, Command, Stdio},
+    sync::Mutex,
+};
 
 pub static PERF_PROFILE_FILE_NAME: &str = "perf_profile";
 pub static PERF_TOP_FUNCTIONS_FILE_NAME: &str = "top_functions";
@@ -34,7 +36,7 @@ impl PerfProfileRaw {
 }
 
 impl CollectData for PerfProfileRaw {
-    fn prepare_data_collector(&mut self, params: CollectorParams) -> Result<()> {
+    fn prepare_data_collector(&mut self, params: &CollectorParams) -> Result<()> {
         match Command::new("perf")
             .stdout(Stdio::null())
             .args([
@@ -73,7 +75,7 @@ impl CollectData for PerfProfileRaw {
         Ok(())
     }
 
-    fn finish_data_collection(&mut self, params: CollectorParams) -> Result<()> {
+    fn finish_data_collection(&mut self, params: &CollectorParams) -> Result<()> {
         let mut child = PERF_CHILD.lock().unwrap();
         match child.as_ref() {
             None => return Ok(()),

--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -115,7 +115,7 @@ impl PerfStatRaw {
 }
 
 impl CollectData for PerfStatRaw {
-    fn prepare_data_collector(&mut self, _params: CollectorParams) -> Result<()> {
+    fn prepare_data_collector(&mut self, _params: &CollectorParams) -> Result<()> {
         let num_cpus = match unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN as libc::c_int) } {
             -1 => {
                 warn!("Could not get the number of cpus in the system with sysconf.");
@@ -567,7 +567,7 @@ mod tests {
         let mut perf_stat = PerfStatRaw::new();
         let params = CollectorParams::new();
 
-        match perf_stat.prepare_data_collector(params.clone()) {
+        match perf_stat.prepare_data_collector(&params) {
             Err(e) => {
                 if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
                     match os_error.kind() {
@@ -593,7 +593,7 @@ mod tests {
         let mut processed_buffer: Vec<ProcessedData> = Vec::new();
         let params = CollectorParams::new();
 
-        match perf_stat.prepare_data_collector(params.clone()) {
+        match perf_stat.prepare_data_collector(&params) {
             Err(e) => {
                 if let Some(os_error) = e.downcast_ref::<std::io::Error>() {
                     match os_error.kind() {

--- a/src/data/processes.rs
+++ b/src/data/processes.rs
@@ -46,7 +46,7 @@ impl Default for ProcessesRaw {
 }
 
 impl CollectData for ProcessesRaw {
-    fn prepare_data_collector(&mut self, _params: CollectorParams) -> Result<()> {
+    fn prepare_data_collector(&mut self, _params: &CollectorParams) -> Result<()> {
         *TICKS_PER_SECOND.lock().unwrap() = procfs::ticks_per_second()? as u64;
         Ok(())
     }
@@ -345,7 +345,7 @@ mod process_test {
     fn test_collect_data() {
         let mut processes = ProcessesRaw::new();
         let params = CollectorParams::new();
-        processes.prepare_data_collector(params.clone()).unwrap();
+        processes.prepare_data_collector(&params).unwrap();
         processes.collect_data(&params).unwrap();
         assert!(!processes.data.is_empty());
     }
@@ -358,12 +358,8 @@ mod process_test {
         let mut processed_buffer: Vec<ProcessedData> = Vec::<ProcessedData>::new();
         let params = CollectorParams::new();
 
-        processes_zero
-            .prepare_data_collector(params.clone())
-            .unwrap();
-        processes_one
-            .prepare_data_collector(params.clone())
-            .unwrap();
+        processes_zero.prepare_data_collector(&params).unwrap();
+        processes_one.prepare_data_collector(&params).unwrap();
         processes_zero.collect_data(&params).unwrap();
         processes_one.collect_data(&params).unwrap();
 

--- a/src/html_files/aperf_run_stats.ts
+++ b/src/html_files/aperf_run_stats.ts
@@ -29,6 +29,7 @@ function getAperfEntry(elem, key, run_data) {
         y: y_print,
         type: 'scatter',
     };
+    let limits = key_limits.get(key);
     var layout = {
         title: `${key}`,
         xaxis: {
@@ -36,6 +37,7 @@ function getAperfEntry(elem, key, run_data) {
         },
         yaxis: {
             title: 'Time (us)',
+            range: [limits.low, limits.high],
         },
     }
     Plotly.newPlot(TESTER, [aperfstat_collect_data, aperfstat_print_data], layout, { frameMargins: 0 });

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -71,14 +71,14 @@ impl DataVisualizer {
         &mut self,
         dir: String,
         name: String,
-        tmp_dir: String,
-        fin_dir: PathBuf,
+        tmp_dir: &Path,
+        fin_dir: &Path,
     ) -> Result<()> {
         let file = get_file(dir.clone(), self.file_name.clone())?;
         let full_path = Path::new("/proc/self/fd").join(file.as_raw_fd().to_string());
         self.report_params.data_dir = PathBuf::from(dir.clone());
-        self.report_params.tmp_dir = PathBuf::from(tmp_dir);
-        self.report_params.report_dir = fin_dir;
+        self.report_params.tmp_dir = tmp_dir.to_path_buf();
+        self.report_params.report_dir = fin_dir.to_path_buf();
         self.report_params.run_name = name.clone();
         self.report_params.data_file_path = fs::read_link(full_path).unwrap();
         self.file_handle = Some(file);
@@ -264,8 +264,8 @@ mod tests {
         dv.init_visualizer(
             "tests/test-data/aperf_2023-07-26_18_37_43/".to_string(),
             "test".to_string(),
-            String::new(),
-            PathBuf::new(),
+            &PathBuf::new(),
+            &PathBuf::new(),
         )
         .unwrap();
         dv.process_raw_data("test".to_string()).unwrap();


### PR DESCRIPTION
This uses the TempDir crate to generate unique temp directories for aperf runs. Also, move to using references where possible for the Data trait.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
