### PR TITLE
Report: Fix issue with '.' in run names

### DIFF
--- a/src/data/utils.rs
+++ b/src/data/utils.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 
 #[derive(Clone, Debug)]
 pub struct CpuInfo {
@@ -39,4 +40,18 @@ pub fn get_cpu_info() -> Result<CpuInfo> {
         }
     }
     Ok(cpu_info)
+}
+
+pub fn notargz_file_name(pbuf: PathBuf) -> Result<String> {
+    if pbuf.file_name().is_none() {
+        return Ok(String::new());
+    }
+    notargz_string_name(pbuf.file_name().unwrap().to_str().unwrap().to_string())
+}
+
+pub fn notargz_string_name(s: String) -> Result<String> {
+    if s.ends_with(".tar.gz") {
+        return Ok(s.strip_suffix(".tar.gz").unwrap().to_string());
+    }
+    Ok(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ impl PerformanceData {
     }
 
     pub fn create_data_archive(&mut self) -> Result<()> {
-        let dir_name = Path::new(&self.init_params.dir_name).file_stem().unwrap();
+        let dir_name = Path::new(&self.init_params.dir_name).file_name().unwrap();
         let archive_path = format!("{}.tar.gz", self.init_params.dir_name);
         let tar_gz = fs::File::create(&archive_path)?;
         let enc = GzEncoder::new(tar_gz, Compression::default());
@@ -446,7 +446,7 @@ impl VisualizationData {
         fin_dir: &Path,
     ) -> Result<String> {
         let dir_path = Path::new(&dir);
-        let dir_name = dir_path.file_stem().unwrap().to_str().unwrap().to_string();
+        let dir_name = crate::data::utils::notargz_file_name(dir_path.to_path_buf())?;
         self.run_names.push(dir_name.clone());
         let visualizers_len = self.visualizers.len();
         let mut error_count = 0;


### PR DESCRIPTION
There is a bug in the report generation if the user collected record data with a run name containing `.`. In such cases, the report generator, since it was using file_stem(), would incorrectly create the report directory and tarball with different names.

To prevent this, use file_name() and a check to remove '.tar.gz' suffix. Also, move to using file_name() instead of file_stem() wherever needed.

[2dots.in.name.tar.gz](https://github.com/user-attachments/files/18832028/2dots.in.name.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
