### PR TITLE
Aperf: Add build options for Release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+lto = true          # Enable link-time optimization. Does not adversely affect speed.
+codegen-units = 1   # Reduce number of codegen units to increase optimizations. Does not adeversely affect speed.
+strip = "debuginfo" # Strip debuginfo only. Stack traces still work. Won't work with debuggers.
+
 [build-dependencies]
 anyhow = "1.0"
 vergen = { version = "8.3", features = ["build", "git", "gitcl"] }


### PR DESCRIPTION
These options allow us to reduce the size of the binary by ~45%. These do not adversely impact the speed of aperf execution.

Original binary size: 20MB
New binary size: 11MB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
