### PR TITLE
Report: Onboard more datatypes for Analytics

### DIFF
--- a/src/data/perf_stat.rs
+++ b/src/data/perf_stat.rs
@@ -1,7 +1,7 @@
 extern crate ctor;
 
 use crate::data::{CollectData, CollectorParams, Data, DataType, ProcessedData, TimeEnum};
-use crate::utils::{DataMetrics, Metric};
+use crate::utils::{add_metrics, DataMetrics, Metric};
 use crate::visualizer::{DataVisualizer, GetData, GraphLimitType, GraphMetadata};
 use crate::{PDError, PERFORMANCE_DATA, VISUALIZATION_DATA};
 use anyhow::Result;
@@ -11,7 +11,6 @@ use log::{error, info, trace, warn};
 use perf_event::events::{Raw, Software};
 use perf_event::{Builder, Counter, Group, ReadFormat};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::PathBuf;
@@ -472,15 +471,7 @@ fn get_values(values: Vec<PerfStat>, key: String, metrics: &mut DataMetrics) -> 
         end_stats.cpus = end_cpu_stats;
         end_values.push(end_stats);
     }
-    if let Some(m) = metrics.values.get_mut(PERF_STAT_FILE_NAME) {
-        m.insert(key, metric.form_stats());
-    } else {
-        let mut metric_map = HashMap::new();
-        metric_map.insert(key, metric.form_stats());
-        metrics
-            .values
-            .insert(PERF_STAT_FILE_NAME.to_string(), metric_map);
-    }
+    add_metrics(key, &mut metric, metrics, PERF_STAT_FILE_NAME.to_string())?;
     let perf_data = EndPerfData {
         data: end_values,
         metadata,

--- a/src/html_files/analytics.ts
+++ b/src/html_files/analytics.ts
@@ -71,4 +71,9 @@ let all_rules: Rules[] = [
     system_info_rules,
     cpu_utilization_rules,
     perf_stat_rules,
+    aperfstats_rules,
+    diskstats_rules,
+    meminfo_rules,
+    netstat_rules,
+    vmstat_rules,
 ];

--- a/src/html_files/aperf_run_stats.ts
+++ b/src/html_files/aperf_run_stats.ts
@@ -1,5 +1,11 @@
 let got_aperfstat_data = false;
 
+let aperfstats_rules = {
+    data_type: "aperf_run_stats",
+    pretty_name: "Aperf Stats",
+    rules: []
+}
+
 function getAperfEntry(elem, key, run_data) {
     var value = JSON.parse(run_data);
     let collect = value.collect;

--- a/src/html_files/disk_stats.ts
+++ b/src/html_files/disk_stats.ts
@@ -1,6 +1,12 @@
 let got_disk_stat_data = false;
 let diskstat_hide_zero_na_graphs = false;
 
+let diskstats_rules = {
+    data_type: "disk_stats",
+    pretty_name: "Disk Stats",
+    rules: []
+}
+
 function getStatValues(elem, key, run_data) {
     var disk_datas = [];
     var data = JSON.parse(run_data);

--- a/src/html_files/meminfo.ts
+++ b/src/html_files/meminfo.ts
@@ -3,6 +3,12 @@ let meminfo_hide_zero_na_graphs = false;
 let TB = 1073741824;
 let GB = 1048576;
 
+let meminfo_rules = {
+    data_type: "meminfo",
+    pretty_name: "Meminfo",
+    rules: []
+}
+
 let meminfo_average: Map<string, number> = new Map<string, number>();
 function form_meminfo_averages() {
     runs_raw.forEach(function (value, index, arr) {

--- a/src/html_files/netstat.ts
+++ b/src/html_files/netstat.ts
@@ -1,6 +1,12 @@
 let got_netstat_data = false;
 let netstat_hide_zero_na_graphs = false;
 
+let netstat_rules = {
+    data_type: "netstat",
+    pretty_name: "Netstat",
+    rules: []
+}
+
 function getNetstatEntries(run, container_id, keys, run_data) {
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];

--- a/src/html_files/vmstat.ts
+++ b/src/html_files/vmstat.ts
@@ -1,6 +1,12 @@
 let got_vmstat_data = false;
 let vmstat_hide_zero_na_graphs = false;
 
+let vmstat_rules = {
+    data_type: "vmstat",
+    pretty_name: "Vmstat",
+    rules: []
+}
+
 function getEntries(run, container_id, keys, run_data) {
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tdigest::TDigest;
@@ -71,4 +72,20 @@ impl Metric {
         self.stats.mean = t.mean();
         ValueType::Stats(self.stats.clone())
     }
+}
+
+pub fn add_metrics(
+    key: String,
+    metric: &mut Metric,
+    metrics: &mut DataMetrics,
+    file: String,
+) -> Result<()> {
+    if let Some(m) = metrics.values.get_mut(&file) {
+        m.insert(key, metric.form_stats());
+    } else {
+        let mut metric_map = HashMap::new();
+        metric_map.insert(key, metric.form_stats());
+        metrics.values.insert(file, metric_map);
+    }
+    Ok(())
 }


### PR DESCRIPTION
Rule writers can start writing rules in the corresponding data type. We are onboarding Netstat, Vmstat, Diskstat, AperfStat, 

[aperf_report_onboarded.tar.gz](https://github.com/user-attachments/files/19393449/aperf_report_onboarded.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
