### PR TITLE
Branch misprediction rule

### DIFF
--- a/src/html_files/perf_stat.ts
+++ b/src/html_files/perf_stat.ts
@@ -14,6 +14,22 @@ let perf_stat_rules = {
                     yield new Finding(`IPC difference between '${ruleOpts.base_run}' and '${ruleOpts.this_run}' is '${diff}'%.`, Status.NotGood);
                 }
             }
+        },
+        {
+            name: "branch-mpki",
+            per_run_rule: function* (ruleOpts: RuleOpts) : Generator<Finding, void, any> {
+                let diff = percent_difference(ruleOpts.base_run_data, ruleOpts.this_run_data);
+                // Branch MPKI increases are generally bad for performance
+                // A 20% threshold is suggested as branch prediction changes can be sensitive
+                if (diff > 20) {
+                    yield new Finding(
+                        `Branch Misprediction is ${diff}% different between '${ruleOpts.base_run}' and '${ruleOpts.this_run}'. ` +
+                        `This can significantly impact performance since every time the CPU predicts incorrectly it has to flush ` +
+                        `the current set of instructions it was working on and start over by fetching new instructions from the correct place.`,
+                        Status.NotGood
+                    );
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
If more than 20% difference between two runs, it should trigger the rule.

Tested with local APerf profiles. Here the output:
```
Branch  Misprediction is 71% different between  'aperf_20250410T181733_PG_old_stable200_m8g24xlarge' and  'aperf_20250410T170035_PG_old_stable300_m8g24xlarge'. This can  significantly impact performance since every time the CPU predicts  incorrectly it has to flush the current set of instructions it was  working on and start over by fetching new instructions from the correct  place
```



