### PR TITLE
Fix interval period check

### DIFF
--- a/src/record.rs
+++ b/src/record.rs
@@ -1,4 +1,5 @@
 use crate::{data, InitParams, PERFORMANCE_DATA};
+use anyhow::anyhow;
 use anyhow::Result;
 use clap::Args;
 use log::{debug, error, info};
@@ -53,11 +54,17 @@ pub fn record(record: &Record, tmp_dir: &Path, runlog: &Path) -> Result<()> {
     let mut run_name = String::new();
     if record.period == 0 {
         error!("Collection period cannot be 0.");
-        return Ok(());
+        return Err(anyhow!("Cannot start recording with the given parameters."));
     }
     if record.interval == 0 {
         error!("Collection interval cannot be 0.");
-        return Ok(());
+        return Err(anyhow!("Cannot start recording with the given parameters."));
+    }
+    // Check if interval > period , if so give error user and exit.
+    if record.interval >= record.period {
+        error!("The overall recording period of {period} seconds needs to be longer than the interval of {interval} seconds.\
+                Please increase the overall recording period or decrease the interval.", interval = record.interval, period =record.period);
+        return Err(anyhow!("Cannot start recording with the given parameters."));
     }
     match &record.run_name {
         Some(r) => run_name = r.clone(),


### PR DESCRIPTION
## Changes Made
Check interval and period passed by the user and:
- If `interval >= period`: an error is logged and the program exits with a clear message.
- If `interval < period`: the program proceeds as normal.

Used return Err(()):
- For conditions where program is exiting with an error, used return Err(()) instead of return Ok(()) which better describes the exit with an error.

## Testing
- eg. Interval>=Period

dev-dsk-parthnk-1d-70bda464 % ./target/release/aperf record --interval 10
[2025-05-30T21:42:03Z ERROR aperf::record] The overall recording period of 10 seconds needs to be longer than the interval of 10 seconds.Please increase the overall recording period or decrease the interval.
Error: Cannot start recording with the given parameters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
