### PR TITLE
Add IOWait CPU time to aggregate CPU utilization graph.

### DIFF
--- a/src/html_files/cpu_utilization.ts
+++ b/src/html_files/cpu_utilization.ts
@@ -117,6 +117,7 @@ function getCpuUtilization(elem, run, run_data) {
         y_irq.push(value.values.irq);
         y_softirq.push(value.values.softirq);
         y_idle.push(value.values.idle);
+	y_iowait.push(value.values.iowait);
         y_steal.push(value.values.steal);
     });
     var user: Partial<Plotly.PlotData> = {


### PR DESCRIPTION
This adds IOWait CPU time to the aggregate CPU utilization graph.

Tested with local Aperf profiles. 

Here's an example CPU utilization graph for IOWait:
<img width="1480" alt="Screenshot 2025-06-11 at 11 43 01 AM" src="https://github.com/user-attachments/assets/70c7e21f-f001-418c-b32b-6056edc347bf" />


And this is what the aggregate CPU utilization graph looks like with this change:
<img width="1499" alt="Screenshot 2025-06-11 at 11 42 40 AM" src="https://github.com/user-attachments/assets/107d26ff-412b-4d05-ba72-ebc9d15a86bc" />
