### PR TITLE
Enable perf_frequency command line option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ To see a step-by-step example, please see our example [here](./EXAMPLE.md)
 
 `--profile` gather profiling data using the 'perf' binary
 
+`-F, --perf-frequency` frequency for perf profiling in Hz (default 99)
+
 `--profile-java` profile JVMs by PID or name using async-profiler (default profiles all JVMs)
 
 `./aperf record -h`

--- a/src/data.rs
+++ b/src/data.rs
@@ -58,6 +58,7 @@ pub struct CollectorParams {
     pub signal: Signal,
     pub runlog: PathBuf,
     pub pmu_config: Option<PathBuf>,
+    pub perf_frequency: u32,
 }
 
 impl CollectorParams {
@@ -73,6 +74,7 @@ impl CollectorParams {
             signal: signal::SIGTERM,
             runlog: PathBuf::new(),
             pmu_config: Option::None,
+            perf_frequency: 99,
         }
     }
 }

--- a/src/data/perf_profile.rs
+++ b/src/data/perf_profile.rs
@@ -48,7 +48,7 @@ impl CollectData for PerfProfileRaw {
                 "-k",
                 "1",
                 "-F",
-                "99",
+                &params.perf_frequency.to_string(),
                 "-e",
                 "cpu-clock:pppH",
                 "-o",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,6 +563,7 @@ pub struct InitParams {
     pub commit_sha_short: String,
     pub tmp_dir: PathBuf,
     pub runlog: PathBuf,
+    pub perf_frequency: u32,
 }
 
 impl InitParams {
@@ -602,6 +603,7 @@ impl InitParams {
             commit_sha_short,
             tmp_dir: PathBuf::from(APERF_TMP),
             runlog: PathBuf::new(),
+            perf_frequency: 99,
         }
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -23,6 +23,10 @@ pub struct Record {
     #[clap(long, value_parser)]
     pub profile: bool,
 
+    /// Frequency for perf profiling (Hz).
+    #[clap(short = 'F', long, value_parser, default_value_t = 99)]
+    pub perf_frequency: u32,
+
     /// Profile JVMs using async-profiler. Specify args using comma separated values. Profiles all JVMs if no args are provided.
     #[clap(long, value_parser, default_missing_value = Some("jps"), value_names = &["PID/Name>,<PID/Name>,...,<PID/Name"], num_args = 0..=1)]
     pub profile_java: Option<String>,
@@ -97,6 +101,7 @@ pub fn record(record: &Record, tmp_dir: &Path, runlog: &Path) -> Result<()> {
             String::from(data::flamegraphs::FLAMEGRAPHS_FILE_NAME),
             String::new(),
         );
+        params.perf_frequency = record.perf_frequency;
     }
 
     PERFORMANCE_DATA.lock().unwrap().set_params(params);

--- a/tests/test_aperf.rs
+++ b/tests/test_aperf.rs
@@ -60,6 +60,7 @@ fn record_with_name(run: String, tempdir: &Path, aperf_tmp: &Path) -> Result<Str
         interval: 1,
         period: 2,
         profile: false,
+        perf_frequency: 99,
         profile_java: None,
         pmu_config: None,
     };


### PR DESCRIPTION
*Issue #, if available:*
Default 99 mayn't be needed for larger runs so giving an option helps. 

*Description of changes:*
Enable an option to overide default 99


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
