### PR TITLE
Add Hotline SPE code profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Prepare build dependencies
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@2080da66123fcc7ec821c7597e9bc40af40d8af6 # 1.73.0
+        uses: dtolnay/rust-toolchain@47f4dd75f027bd6cfe06f3dc15ddfcb07acc7e4e # 1.74.0
         with:
           components: rustfmt, clippy
       - name: Install Node
@@ -40,6 +40,16 @@ jobs:
         run: sudo apt install -y build-essential
       - name: Install musl
         run: sudo apt install -y musl-tools
+      - name: Install Hotline dependencies
+        run: |
+          sudo apt-get install \
+            libdw-dev \
+            libelf-dev \
+            libcapstone-dev \
+            zlib1g-dev \
+            liblzma-dev \
+            libbz2-dev \
+            libzstd-dev
 
       # Tests and static analysis
       - name: Set perf_event_paranoid to 0
@@ -47,7 +57,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose -- --nocapture --color always
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 
@@ -56,6 +66,21 @@ jobs:
         run: |
           rustup target add $(arch)-unknown-linux-musl
           cargo build --release --target $(arch)-unknown-linux-musl
+
+      # Is not published, but ensures that Hotline can be built
+      # [hotline] tests will fail since it is not Graviton metal,
+      # but they are graceful and the test suite should pass
+      - name: Build and test dynamically linked artifacts
+        run: |
+          if [ $(arch) = "aarch64" ]; then
+            cargo clippy --all-targets --features hotline
+            cargo test --features hotline --verbose -- --nocapture --color always
+          fi
+
+          
+      - name: Ensure no runtime dependencies
+        run: |
+          ldd target/$(arch)-unknown-linux-musl/release/aperf 2>&1 | grep -E "not a dynamic executable|statically linked"
       - name: Archive release artifacts
         run: tar -zcvf artifacts.tar.gz -C target/$(arch)-unknown-linux-musl/release aperf
       - name: Upload x86_64 release artifacts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ strip = "debuginfo" # Strip debuginfo only. Stack traces still work. Won't work 
 [build-dependencies]
 anyhow = "1.0"
 vergen = { version = "8.3", features = ["build", "git", "gitcl"] }
+cc = "1.0"
 
 [lib]
 name = "aperf"
@@ -60,3 +61,9 @@ tempfile = "3"
 serial_test = "3.1.1"
 log4rs = "1.3.0"
 tdigest = "0.2"
+csv = "1.2"
+csv-to-html = "0.5.10"
+
+[features]
+default = []
+hotline = []

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() -> Result<()> {
 
     println!("cargo:rerun-if-changed=package.json");
     println!("cargo:rerun-if-changed=package-lock.json");
+
     match Command::new("npm").arg("install").spawn() {
         Err(_proc) => {
             println!("Build requires npm, but it was not found. Please install Node >= 16.16.0.");
@@ -37,6 +38,51 @@ fn main() -> Result<()> {
     if !status.success() {
         println!("Failed to compile typescript.");
         std::process::exit(1);
+    }
+
+    #[cfg(all(feature = "hotline", not(target_arch = "aarch64")))]
+    compile_error!("The 'hotline' feature is only supported on aarch64 architecture");
+
+    #[cfg(feature = "hotline")]
+    {
+        println!("cargo:rerun-if-changed=src/hotline/*");
+        cc::Build::new()
+            .files([
+                "src/hotline/bmiss_map.c",
+                "src/hotline/btree.c",
+                "src/hotline/config.c",
+                "src/hotline/finode_map.c",
+                "src/hotline/fname_binary_map.c",
+                "src/hotline/fname_map.c",
+                "src/hotline/hotline.c",
+                "src/hotline/lat_map.c",
+                "src/hotline/report.c",
+                "src/hotline/sys.c",
+                "src/hotline/vec.c",
+                "src/hotline/tests/test_bmiss_map.c",
+                "src/hotline/tests/test_config.c",
+                "src/hotline/tests/test_finode_map.c",
+                "src/hotline/tests/test_fname_binary_map.c",
+                "src/hotline/tests/test_fname_map.c",
+                "src/hotline/tests/test_lat_map.c",
+                "src/hotline/tests/test.c",
+            ])
+            .includes(["src/hotline"])
+            .flag("-Werror")
+            .flag("-Wextra")
+            .flag("-Wall")
+            .opt_level(3)
+            .compile("hotline");
+
+        println!("cargo:rustc-link-lib=dylib=dw");
+        println!("cargo:rustc-link-lib=dylib=elf");
+        println!("cargo:rustc-link-lib=dylib=capstone");
+        println!("cargo:rustc-link-lib=dylib=z");
+        println!("cargo:rustc-link-lib=dylib=lzma");
+        println!("cargo:rustc-link-lib=dylib=bz2");
+        println!("cargo:rustc-link-lib=dylib=zstd");
+
+        println!("Building with Hotline support.");
     }
     Ok(())
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,6 +4,7 @@ pub mod constants;
 pub mod cpu_utilization;
 pub mod diskstats;
 pub mod flamegraphs;
+pub mod hotline;
 pub mod interrupts;
 pub mod java_profile;
 pub mod kernel_config;
@@ -27,6 +28,7 @@ use chrono::prelude::*;
 use cpu_utilization::{CpuUtilization, CpuUtilizationRaw};
 use diskstats::{Diskstats, DiskstatsRaw};
 use flamegraphs::{Flamegraph, FlamegraphRaw};
+use hotline::{Hotline, HotlineRaw};
 use interrupts::{InterruptData, InterruptDataRaw};
 use java_profile::{JavaProfile, JavaProfileRaw};
 use kernel_config::KernelConfig;
@@ -59,6 +61,9 @@ pub struct CollectorParams {
     pub runlog: PathBuf,
     pub pmu_config: Option<PathBuf>,
     pub perf_frequency: u32,
+    pub hotline_frequency: u32,
+    pub interval: u64,
+    pub num_to_report: u32,
 }
 
 impl CollectorParams {
@@ -75,6 +80,9 @@ impl CollectorParams {
             runlog: PathBuf::new(),
             pmu_config: Option::None,
             perf_frequency: 99,
+            hotline_frequency: 1000,
+            interval: 1,
+            num_to_report: 5000,
         }
     }
 }
@@ -135,6 +143,9 @@ impl DataType {
         self.collector_params.tmp_dir = param.tmp_dir.clone();
         self.collector_params.runlog = param.runlog.clone();
         self.collector_params.pmu_config = param.pmu_config.clone();
+        self.collector_params.interval = param.interval;
+        self.collector_params.hotline_frequency = param.hotline_frequency;
+        self.collector_params.num_to_report = param.num_to_report;
 
         self.file_handle = Some(
             OpenOptions::new()
@@ -311,7 +322,8 @@ data!(
     NetstatRaw,
     PerfProfileRaw,
     FlamegraphRaw,
-    JavaProfileRaw
+    JavaProfileRaw,
+    HotlineRaw
 );
 
 processed_data!(
@@ -327,6 +339,7 @@ processed_data!(
     MeminfoData,
     Netstat,
     PerfProfile,
+    Hotline,
     Flamegraph,
     AperfStat,
     AperfRunlog,

--- a/src/data/hotline.rs
+++ b/src/data/hotline.rs
@@ -1,0 +1,383 @@
+extern crate ctor;
+
+use crate::data::{CollectData, CollectorParams, ProcessedData};
+use crate::utils::DataMetrics;
+use crate::visualizer::GetData;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "hotline")]
+use {
+    crate::visualizer::ReportParams,
+    crate::{
+        data::{Data, DataType},
+        visualizer::DataVisualizer,
+        PERFORMANCE_DATA, VISUALIZATION_DATA,
+    },
+    ctor::ctor,
+    libc::{_exit, fork, geteuid, killpg, setpgid, waitpid, SIGTERM},
+    log::{info, warn},
+    std::{
+        env,
+        ffi::CString,
+        fs,
+        os::raw::{c_char, c_int},
+        panic,
+    },
+};
+
+#[cfg(feature = "hotline")]
+extern "C" {
+    fn hotline(argc: c_int, argv: *const *const i8) -> c_int;
+    fn deserialize_maps(argc: c_int, argv: *const *const i8) -> c_int;
+}
+
+pub static HOTLINE_FILE_NAME: &str = "hotline_profile";
+
+#[cfg(feature = "hotline")]
+pub fn check_preconditions() -> Result<bool> {
+    let mut all_conditions_met = true;
+
+    // Check root privileges
+    let euid = unsafe { geteuid() } == 0;
+    if !euid {
+        warn!("Not running with root privileges. Please run with sudo.");
+        all_conditions_met = false;
+    }
+
+    // Check KPTI status
+    let cmdline = fs::read_to_string("/proc/cmdline")?;
+    let kpti_off = cmdline.contains("kpti=off");
+    if !kpti_off {
+        warn!("KPTI is not disabled. Add 'kpti=off' to GRUB_CMDLINE_LINUX_DEFAULT and reboot.");
+        all_conditions_met = false;
+    }
+
+    // Check kptr_restrict
+    let kptr_value = fs::read_to_string("/proc/sys/kernel/kptr_restrict")?
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(-1);
+    if kptr_value != 0 {
+        warn!(
+            "kptr_restrict is not set to 0. Run: echo 0 | sudo tee /proc/sys/kernel/kptr_restrict"
+        );
+        all_conditions_met = false;
+    }
+
+    // Check perf_event_paranoid
+    let paranoid_value = fs::read_to_string("/proc/sys/kernel/perf_event_paranoid")?
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(4);
+    if paranoid_value != -1 {
+        warn!("perf_event_paranoid is not set to -1. Run: echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid");
+        all_conditions_met = false;
+    }
+
+    // Check /proc/kallsyms readable
+    let kallsyms_readable = match fs::metadata("/proc/kallsyms") {
+        Ok(metadata) => metadata.permissions().readonly(),
+        Err(_) => false,
+    };
+    if !kallsyms_readable {
+        warn!("/proc/kallsyms is not readable. Run: sudo chmod +r /proc/kallsyms");
+        all_conditions_met = false;
+    }
+
+    if !all_conditions_met {
+        Ok(false)
+    } else {
+        info!("Starting hotline");
+        Ok(true)
+    }
+}
+
+#[cfg(feature = "hotline")]
+pub mod hotline_reports {
+    use super::ReportParams;
+    use std::error::Error;
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::Path;
+
+    struct ReportConfig<'a> {
+        table_id: &'a str,
+        filename: &'a str,
+    }
+
+    const REPORT_CONFIGS: [ReportConfig; 5] = [
+        ReportConfig {
+            table_id: "completion_node",
+            filename: "hotline_lat_map_completion_report.csv",
+        },
+        ReportConfig {
+            table_id: "execution_latency",
+            filename: "hotline_lat_map_exec_report.csv",
+        },
+        ReportConfig {
+            table_id: "issue_latency",
+            filename: "hotline_lat_map_issue_report.csv",
+        },
+        ReportConfig {
+            table_id: "translation_latency",
+            filename: "hotline_lat_map_translation_report.csv",
+        },
+        ReportConfig {
+            table_id: "branch",
+            filename: "hotline_bmiss_map.csv",
+        },
+    ];
+
+    pub fn generate_html_files(params: &ReportParams) -> Result<(), Box<dyn Error>> {
+        // First, create the CSS file
+        for config in REPORT_CONFIGS {
+            let csv_string = std::fs::read_to_string(format!(
+                "{}/{}",
+                params.data_dir.display(),
+                config.filename
+            ))?;
+            let table_html = csv_to_html::convert(&csv_string, &b',', &true);
+
+            // Use relative path to CSS file
+            let full_html = format!(
+                r#"<!DOCTYPE html>
+                <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <link rel="stylesheet" href="../../index.css">
+                </head>
+                <body>
+                    {}
+                </body>
+                </html>"#,
+                table_html
+            );
+
+            let output_path = Path::new(&params.report_dir)
+                .join("data")
+                .join("js")
+                .join(format!("{}.html", config.table_id));
+            let mut file = File::create(output_path)?;
+            file.write_all(full_html.as_bytes())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HotlineRaw {
+    pid: i32,
+    launched: bool,
+}
+
+impl HotlineRaw {
+    fn new() -> Self {
+        HotlineRaw {
+            pid: 0,
+            launched: false,
+        }
+    }
+}
+
+impl CollectData for HotlineRaw {
+    #[cfg(feature = "hotline")]
+    fn prepare_data_collector(&mut self, params: &CollectorParams) -> Result<()> {
+        match check_preconditions() {
+            Ok(false) => {
+                warn!("Skipping Hotline.");
+                self.launched = false;
+                return Ok(());
+            }
+            Err(e) => {
+                warn!("Failed to check preconditions: {}", e);
+                self.launched = false;
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        let args = vec![
+            CString::new("hotline").unwrap(),
+            CString::new("--wakeup_period").unwrap(),
+            CString::new(params.interval.to_string()).unwrap(),
+            CString::new("--hotline_frequency").unwrap(),
+            CString::new(params.hotline_frequency.to_string()).unwrap(),
+            CString::new("--timeout").unwrap(),
+            CString::new(params.collection_time.to_string()).unwrap(),
+            CString::new("--data_dir").unwrap(),
+            CString::new(params.data_dir.to_str().unwrap()).unwrap(),
+        ];
+
+        let argv: Vec<*const c_char> = args.iter().map(|arg| arg.as_ptr()).collect();
+
+        unsafe {
+            match fork() {
+                -1 => {
+                    eprintln!("Fork failed");
+                    Ok(()) // Return Ok even if fork fails
+                }
+                0 => {
+                    // Child process
+                    if setpgid(0, 0) == -1 {
+                        eprintln!("Failed to set process group");
+                        _exit(1);
+                    }
+
+                    // Setup signal handlers
+                    let mut sigset = std::mem::MaybeUninit::uninit();
+                    libc::sigemptyset(sigset.as_mut_ptr());
+                    libc::sigaddset(sigset.as_mut_ptr(), SIGTERM);
+                    libc::sigprocmask(libc::SIG_UNBLOCK, sigset.as_ptr(), std::ptr::null_mut());
+
+                    let result = hotline(args.len() as c_int, argv.as_ptr() as *const *const i8);
+                    _exit(result);
+                }
+                pid => {
+                    // Parent process
+                    self.pid = pid;
+                    self.launched = true;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn collect_data(&mut self, _params: &CollectorParams) -> Result<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "hotline")]
+    fn finish_data_collection(&mut self, params: &CollectorParams) -> Result<()> {
+        if !self.launched {
+            return Ok(());
+        }
+
+        unsafe {
+            // Send SIGTERM to the process group
+            if killpg(self.pid, SIGTERM) == -1 {
+                let err = std::io::Error::last_os_error();
+                eprintln!("Warning: Failed to kill process group: {}", err);
+            }
+
+            // Wait for the child process to finish
+            let mut status: c_int = 0;
+            match waitpid(self.pid, &mut status, 0) {
+                -1 => {
+                    let err = std::io::Error::last_os_error();
+                    eprintln!("Warning: Failed to wait for child process: {}", err);
+                }
+                _ => {
+                    if !libc::WIFEXITED(status) && !libc::WIFSIGNALED(status) {
+                        return Err(anyhow::anyhow!("Child process terminated abnormally"));
+                    }
+                }
+            }
+        }
+
+        // Child process has been completely killed. Now we can process the serialized data.
+        let args = vec![
+            CString::new("hotline").unwrap(),
+            CString::new("--num_to_report").unwrap(),
+            CString::new(params.num_to_report.to_string()).unwrap(),
+            CString::new("--data_dir").unwrap(),
+            CString::new(params.data_dir.to_str().unwrap()).unwrap(),
+        ];
+
+        let argv: Vec<*const c_char> = args.iter().map(|arg| arg.as_ptr()).collect();
+
+        // Run deserialize_maps in a child process
+        unsafe {
+            match fork() {
+                -1 => {
+                    eprintln!("Fork failed");
+                }
+                0 => {
+                    // Child process
+                    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        deserialize_maps(args.len() as c_int, argv.as_ptr() as *mut *const i8);
+                    }));
+                    match result {
+                        Ok(_) => _exit(0),
+                        Err(_) => _exit(1),
+                    }
+                }
+                pid => {
+                    // Parent process
+                    let mut status: c_int = 0;
+                    if waitpid(pid, &mut status, 0) == -1 {
+                        eprintln!("Failed to wait for deserialize_maps process");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Hotline {}
+
+impl Hotline {
+    pub fn new() -> Self {
+        Hotline {}
+    }
+}
+
+impl GetData for Hotline {
+    #[cfg(feature = "hotline")]
+    fn custom_raw_data_parser(&mut self, params: ReportParams) -> Result<Vec<ProcessedData>> {
+        match hotline_reports::generate_html_files(&params) {
+            Ok(_) => (),
+            Err(e) => eprintln!("Warning: Failed to generate HTML tables: {}", e),
+        }
+
+        Ok(vec![])
+    }
+
+    fn get_calls(&mut self) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+
+    fn get_data(
+        &mut self,
+        _: Vec<ProcessedData>,
+        _query: String,
+        _metrics: &mut DataMetrics,
+    ) -> Result<String> {
+        Ok("".to_string())
+    }
+}
+
+#[ctor]
+#[cfg(feature = "hotline")]
+fn init_hotline_profile() {
+    let hotline_raw = HotlineRaw::new();
+    let file_name = HOTLINE_FILE_NAME.to_string();
+    let dt = DataType::new(
+        Data::HotlineRaw(hotline_raw.clone()),
+        file_name.clone(),
+        false,
+    );
+    let hotline_profile = Hotline::new();
+    let js_file_name = file_name.clone() + ".js";
+    let mut dv = DataVisualizer::new(
+        ProcessedData::Hotline(hotline_profile.clone()),
+        file_name.clone(),
+        js_file_name,
+        include_str!(concat!(env!("JS_DIR"), "/hotline.js")).to_string(),
+        file_name.clone(),
+    );
+    dv.has_custom_raw_data_parser();
+
+    PERFORMANCE_DATA
+        .lock()
+        .unwrap()
+        .add_datatype(file_name.clone(), dt);
+
+    VISUALIZATION_DATA
+        .lock()
+        .unwrap()
+        .add_visualizer(file_name.clone(), dv);
+}

--- a/src/hotline/bmiss_map.c
+++ b/src/hotline/bmiss_map.c
@@ -1,0 +1,124 @@
+#include "bmiss_map.h"
+
+#include <string.h>
+
+#include "log.h"
+
+struct btree *bmiss_map = NULL;
+
+/// @brief B-Tree function to compare the branch miss map entries. Order is
+/// compared with ino first as
+///        it is most likely to vary, then maj, min, and ino_generation (which
+///        should rarely change).
+/// @param a First element to compare
+/// @param b Second element to compare
+/// @param udata Unused
+/// @return 1 if a > b, -1 if a < b, 0 if equal
+int bmiss_map_compare(const void *a, const void *b, void *udata) {
+  (void)udata;
+  const bmiss_map_entry_t *ua = a;
+  const bmiss_map_entry_t *ub = b;
+
+  // Compare ino first as it's likely to be unique most often
+  if (ua->finode.ino > ub->finode.ino)
+    return 1;
+  else if (ua->finode.ino < ub->finode.ino)
+    return -1;
+
+  // then check offset as it should never be the same between two lat_map_entry_ts with the same
+  // file
+  if (ua->offset < ub->offset)
+    return -1;
+  else if (ua->offset > ub->offset)
+    return 1;
+
+  // then check the device associated info
+  if (ua->finode.maj > ub->finode.maj)
+    return 1;
+  else if (ua->finode.maj < ub->finode.maj)
+    return -1;
+
+  if (ua->finode.min > ub->finode.min)
+    return 1;
+  else if (ua->finode.min < ub->finode.min)
+    return -1;
+
+  // this should rarely change so check if last
+  if (ua->finode.ino_generation > ub->finode.ino_generation)
+    return 1;
+  else if (ua->finode.ino_generation < ub->finode.ino_generation)
+    return -1;
+
+  return 0;
+}
+
+/// @brief Initializes the BMISS_MAP
+void init_bmiss_map() {
+  bmiss_map = btree_new(sizeof(bmiss_map_entry_t), 0, bmiss_map_compare, NULL);
+  btree_clear(bmiss_map);
+}
+
+/// @brief Inserts a bmiss_map_entry_t into the BMISS_MAP
+/// @param entry_to_insert Entry to insert
+inline void insert_bmiss_map(bmiss_map_entry_t *entry_to_insert) {
+  ASSERT(entry_to_insert, "Entry to insert is NULL.");
+
+  bmiss_map_entry_t tmp_entry = {0};
+
+  bmiss_map_entry_t *entry = (bmiss_map_entry_t *)btree_get(bmiss_map, entry_to_insert);
+
+  if (entry == NULL) {
+    entry = &tmp_entry;
+    entry->finode = entry_to_insert->finode;
+    entry->offset = entry_to_insert->offset;
+  }
+
+  bmiss_map_entry_t updated_entry = {0};
+
+  updated_entry.finode = entry->finode;
+  updated_entry.offset = entry->offset;
+
+  updated_entry.count = entry->count + entry_to_insert->count;
+  updated_entry.mispredicted = entry->mispredicted + entry_to_insert->mispredicted;
+  updated_entry.branch_type = entry_to_insert->branch_type;
+
+  btree_set(bmiss_map, &updated_entry);
+  ASSERT(!btree_oom(bmiss_map), "B-Miss Map OOM.");
+}
+
+/// @brief Parses the raw SPE record into the format the BMISS_MAP uses
+/// @param record Raw SPE record
+/// @param entry B-Tree entry to populate
+/// @param filename filename to assign into the entry, decoded from
+/// `pc_to_file_offset`
+/// @param offset offset to assign into the entry, decoded from
+/// `pc_to_file_offset`
+inline void parse_bmiss_map_entry(spe_record_raw_t *record, bmiss_map_entry_t *entry,
+                                  finode_t *finode, uint64_t offset) {
+  ASSERT(entry && record && finode, "Invalid arguments to parse.");
+
+  memset(entry, 0, sizeof(bmiss_map_entry_t));
+
+  entry->count = 1;
+  entry->finode.ino = finode->ino;
+  entry->finode.maj = finode->maj;
+  entry->finode.min = finode->min;
+  entry->finode.ino_generation = finode->ino_generation;
+  entry->offset = offset;
+
+  entry->mispredicted = (record->events_packet & AUX_EVENT_BRANCH_MISS) ? 1 : 0;
+  entry->branch_type = record->type;
+}
+
+/// @brief Combines parse and insert with inline because these are called very
+/// frequently.
+/// @param record Record to parse and insert
+/// @param finode Finode of file associated with a virtual address
+/// @param offset Offset into the file
+void parse_and_insert_bmiss_entry(spe_record_raw_t *record, finode_t *finode, uint64_t offset) {
+  bmiss_map_entry_t bmiss_entry = {0};
+  // parse_bmiss_map_entry and insert_bmiss_map are inlined for potential
+  // compiler optimizations
+  parse_bmiss_map_entry(record, &bmiss_entry, finode, offset);
+  insert_bmiss_map(&bmiss_entry);
+}

--- a/src/hotline/bmiss_map.h
+++ b/src/hotline/bmiss_map.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "btree.h"
+#include "finode_map.h"
+#include "perf_interface.h"
+
+/// @brief B-Tree struct definition for the SPE branch data.
+typedef struct bmiss_map_entry {
+  union {  // union allows data storing and report generation to use the same
+           // parameters rather than having to redefine them each time.
+    finode_t finode;
+    char *filename;
+  };
+  uint64_t offset;
+  uint64_t count;
+  uint64_t mispredicted;
+  uint8_t branch_type;
+} bmiss_map_entry_t;
+
+void init_bmiss_map();
+void insert_bmiss_map(bmiss_map_entry_t *entry_to_insert);
+void parse_bmiss_map_entry(spe_record_raw_t *record, bmiss_map_entry_t *entry, finode_t *finode,
+                           uint64_t offset);
+void parse_and_insert_bmiss_entry(spe_record_raw_t *record, finode_t *finode, uint64_t offset);
+extern struct btree *bmiss_map;

--- a/src/hotline/btree.c
+++ b/src/hotline/btree.c
@@ -1,0 +1,1293 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2020 Joshua J Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+// Copyright 2020 Joshua J Baker. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef BTREE_STATIC
+#include "btree.h"
+#else
+#define BTREE_EXTERN static
+#endif
+
+#ifndef BTREE_EXTERN
+#define BTREE_EXTERN
+#endif
+
+static void *(*_btree_malloc)(size_t) = NULL;
+static void (*_btree_free)(void *) = NULL;
+
+// DEPRECATED: use `btree_new_with_allocator`
+BTREE_EXTERN
+void btree_set_allocator(void *(malloc)(size_t), void (*free)(void *)) {
+  _btree_malloc = malloc;
+  _btree_free = free;
+}
+
+enum btree_delact {
+  BTREE_DELKEY,
+  BTREE_POPFRONT,
+  BTREE_POPBACK,
+  BTREE_POPMAX,
+};
+
+static size_t btree_align_size(size_t size) {
+  size_t boundary = sizeof(uintptr_t);
+  return size < boundary         ? boundary
+         : size & (boundary - 1) ? size + boundary - (size & (boundary - 1))
+                                 : size;
+}
+
+#ifdef BTREE_NOATOMICS
+typedef int btree_rc_t;
+static int btree_rc_load(btree_rc_t *ptr) { return *ptr; }
+static int btree_rc_fetch_sub(btree_rc_t *ptr, int val) {
+  int rc = *ptr;
+  *ptr -= val;
+  return rc;
+}
+static int btree_rc_fetch_add(btree_rc_t *ptr, int val) {
+  int rc = *ptr;
+  *ptr += val;
+  return rc;
+}
+#else
+#include <stdatomic.h>
+typedef atomic_int btree_rc_t;
+static int btree_rc_load(btree_rc_t *ptr) { return atomic_load(ptr); }
+static int btree_rc_fetch_sub(btree_rc_t *ptr, int delta) { return atomic_fetch_sub(ptr, delta); }
+static int btree_rc_fetch_add(btree_rc_t *ptr, int delta) { return atomic_fetch_add(ptr, delta); }
+#endif
+
+struct btree_node {
+  btree_rc_t rc;
+  bool leaf;
+  size_t nitems : 16;
+  char *items;
+  struct btree_node *children[];
+};
+
+struct btree {
+  void *(*malloc)(size_t);
+  void *(*realloc)(void *, size_t);
+  void (*free)(void *);
+  int (*compare)(const void *a, const void *b, void *udata);
+  int (*searcher)(const void *items, size_t nitems, const void *key, bool *found, void *udata);
+  bool (*item_clone)(const void *item, void *into, void *udata);
+  void (*item_free)(const void *item, void *udata);
+  void *udata;              // user data
+  struct btree_node *root;  // root node or NULL if empty tree
+  size_t count;             // number of items in tree
+  size_t height;            // height of tree from root to leaf
+  size_t max_items;         // max items allowed per node before needing split
+  size_t min_items;         // min items allowed per node before needing join
+  size_t elsize;            // size of user item
+  bool oom;                 // last write operation failed due to no memory
+  size_t spare_elsize;      // size of each spare element. This is aligned
+  char spare_data[];        // spare element spaces for various operations
+};
+
+static void *btree_spare_at(const struct btree *btree, size_t index) {
+  return (void *)(btree->spare_data + btree->spare_elsize * index);
+}
+
+BTREE_EXTERN
+void btree_set_searcher(struct btree *btree,
+                        int (*searcher)(const void *items, size_t nitems, const void *key,
+                                        bool *found, void *udata)) {
+  btree->searcher = searcher;
+}
+
+#define BTREE_NSPARES 512
+#define BTREE_SPARE_RETURN btree_spare_at(btree, 0)  // returned values
+#define BTREE_SPARE_NODE btree_spare_at(btree, 1)    // clone in btree_node_copy
+#define BTREE_SPARE_POPMAX btree_spare_at(btree, 2)  // btree_delete popmax
+#define BTREE_SPARE_CLONE btree_spare_at(btree, 3)   // cloned inputs
+
+static void *btree_get_item_at(struct btree *btree, struct btree_node *node, size_t index) {
+  return node->items + btree->elsize * index;
+}
+
+static void btree_set_item_at(struct btree *btree, struct btree_node *node, size_t index,
+                              const void *item) {
+  void *slot = btree_get_item_at(btree, node, index);
+  memcpy(slot, item, btree->elsize);
+}
+
+static void btree_swap_item_at(struct btree *btree, struct btree_node *node, size_t index,
+                               const void *item, void *into) {
+  void *ptr = btree_get_item_at(btree, node, index);
+  memcpy(into, ptr, btree->elsize);
+  memcpy(ptr, item, btree->elsize);
+}
+
+static void btree_copy_item_into(struct btree *btree, struct btree_node *node, size_t index,
+                                 void *into) {
+  memcpy(into, btree_get_item_at(btree, node, index), btree->elsize);
+}
+
+static void btree_node_shift_right(struct btree *btree, struct btree_node *node, size_t index) {
+  size_t num_items_to_shift = node->nitems - index;
+  memmove(node->items + btree->elsize * (index + 1), node->items + btree->elsize * index,
+          num_items_to_shift * btree->elsize);
+  if (!node->leaf) {
+    memmove(&node->children[index + 1], &node->children[index],
+            (num_items_to_shift + 1) * sizeof(struct btree_node *));
+  }
+  node->nitems++;
+}
+
+static void btree_node_shift_left(struct btree *btree, struct btree_node *node, size_t index,
+                                  bool for_merge) {
+  size_t num_items_to_shift = node->nitems - index - 1;
+  memmove(node->items + btree->elsize * index, node->items + btree->elsize * (index + 1),
+          num_items_to_shift * btree->elsize);
+  if (!node->leaf) {
+    if (for_merge) {
+      index++;
+      num_items_to_shift--;
+    }
+    memmove(&node->children[index], &node->children[index + 1],
+            (num_items_to_shift + 1) * sizeof(struct btree_node *));
+  }
+  node->nitems--;
+}
+
+static void btree_copy_item(struct btree *btree, struct btree_node *node_a, size_t index_a,
+                            struct btree_node *node_b, size_t index_b) {
+  memcpy(btree_get_item_at(btree, node_a, index_a), btree_get_item_at(btree, node_b, index_b),
+         btree->elsize);
+}
+
+static void btree_node_join(struct btree *btree, struct btree_node *left,
+                            struct btree_node *right) {
+  memcpy(left->items + btree->elsize * left->nitems, right->items, right->nitems * btree->elsize);
+  if (!left->leaf) {
+    memcpy(&left->children[left->nitems], &right->children[0],
+           (right->nitems + 1) * sizeof(struct btree_node *));
+  }
+  left->nitems += right->nitems;
+}
+
+static int _btree_compare(const struct btree *btree, const void *a, const void *b) {
+  return btree->compare(a, b, btree->udata);
+}
+
+static size_t btree_node_bsearch(const struct btree *btree, struct btree_node *node,
+                                 const void *key, bool *found) {
+  size_t i = 0;
+  size_t n = node->nitems;
+  while (i < n) {
+    size_t j = (i + n) >> 1;
+    void *item = btree_get_item_at((void *)btree, node, j);
+    int cmp = _btree_compare(btree, key, item);
+    if (cmp == 0) {
+      *found = true;
+      return j;
+    } else if (cmp < 0) {
+      n = j;
+    } else {
+      i = j + 1;
+    }
+  }
+  *found = false;
+  return i;
+}
+
+static int btree_node_bsearch_hint(const struct btree *btree, struct btree_node *node,
+                                   const void *key, bool *found, uint64_t *hint, int depth) {
+  int low = 0;
+  int high = node->nitems - 1;
+  if (hint && depth < 8) {
+    size_t index = (size_t)((uint8_t *)hint)[depth];
+    if (index > 0) {
+      if (index > (size_t)(node->nitems - 1)) {
+        index = node->nitems - 1;
+      }
+      void *item = btree_get_item_at((void *)btree, node, (size_t)index);
+      int cmp = _btree_compare(btree, key, item);
+      if (cmp == 0) {
+        *found = true;
+        return index;
+      }
+      if (cmp > 0) {
+        low = index + 1;
+      } else {
+        high = index - 1;
+      }
+    }
+  }
+  int index;
+  while (low <= high) {
+    int mid = (low + high) / 2;
+    void *item = btree_get_item_at((void *)btree, node, (size_t)mid);
+    int cmp = _btree_compare(btree, key, item);
+    if (cmp == 0) {
+      *found = true;
+      index = mid;
+      goto done;
+    }
+    if (cmp < 0) {
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+  *found = false;
+  index = low;
+done:
+  if (hint && depth < 8) {
+    ((uint8_t *)hint)[depth] = (uint8_t)index;
+  }
+  return index;
+}
+
+static size_t btree_memsize(size_t elsize, size_t *spare_elsize) {
+  size_t size = btree_align_size(sizeof(struct btree));
+  size_t elsize_aligned = btree_align_size(elsize);
+  size += elsize_aligned * BTREE_NSPARES;
+  if (spare_elsize) *spare_elsize = elsize_aligned;
+  return size;
+}
+
+BTREE_EXTERN
+struct btree *btree_new_with_allocator(void *(*malloc_)(size_t), void *(*realloc_)(void *, size_t),
+                                       void (*free_)(void *), size_t elsize, size_t max_items,
+                                       int (*compare)(const void *a, const void *b, void *udata),
+                                       void *udata) {
+  (void)realloc_;  // realloc not used
+  malloc_ = malloc_ ? malloc_ : _btree_malloc ? _btree_malloc : malloc;
+  free_ = free_ ? free_ : _btree_free ? _btree_free : free;
+
+  // normalize max_items
+  size_t spare_elsize;
+  size_t size = btree_memsize(elsize, &spare_elsize);
+  struct btree *btree = malloc_(size);
+  if (!btree) {
+    return NULL;
+  }
+  memset(btree, 0, size);
+  size_t deg = max_items / 2;
+  deg = deg == 0 ? 128 : deg == 1 ? 2 : deg;
+  btree->max_items = deg * 2 - 1;  // max items per node. max children is +1
+  if (btree->max_items > 2045) {
+    // there must be a reasonable limit.
+    btree->max_items = 2045;
+  }
+  btree->min_items = btree->max_items / 2;
+  btree->compare = compare;
+  btree->elsize = elsize;
+  btree->udata = udata;
+  btree->malloc = malloc_;
+  btree->free = free_;
+  btree->spare_elsize = spare_elsize;
+  return btree;
+}
+
+BTREE_EXTERN
+struct btree *btree_new(size_t elsize, size_t max_items,
+                        int (*compare)(const void *a, const void *b, void *udata), void *udata) {
+  return btree_new_with_allocator(NULL, NULL, NULL, elsize, max_items, compare, udata);
+}
+
+static size_t btree_node_size(struct btree *btree, bool leaf, size_t *items_offset) {
+  size_t size = sizeof(struct btree_node);
+  if (!leaf) {
+    // add children as flexible array
+    size += sizeof(struct btree_node *) * (btree->max_items + 1);
+  }
+  if (items_offset) *items_offset = size;
+  size += btree->elsize * btree->max_items;
+  size = btree_align_size(size);
+  return size;
+}
+
+static struct btree_node *btree_node_new(struct btree *btree, bool leaf) {
+  size_t items_offset;
+  size_t size = btree_node_size(btree, leaf, &items_offset);
+  struct btree_node *node = btree->malloc(size);
+  if (!node) {
+    return NULL;
+  }
+  memset(node, 0, size);
+  node->leaf = leaf;
+  node->items = (char *)node + items_offset;
+  return node;
+}
+
+static void btree_node_free(struct btree *btree, struct btree_node *node) {
+  if (btree_rc_fetch_sub(&node->rc, 1) > 0) {
+    return;
+  }
+  if (!node->leaf) {
+    for (size_t i = 0; i < (size_t)(node->nitems + 1); i++) {
+      btree_node_free(btree, node->children[i]);
+    }
+  }
+  if (btree->item_free) {
+    for (size_t i = 0; i < node->nitems; i++) {
+      void *item = btree_get_item_at(btree, node, i);
+      btree->item_free(item, btree->udata);
+    }
+  }
+  btree->free(node);
+}
+
+static struct btree_node *btree_node_copy(struct btree *btree, struct btree_node *node) {
+  struct btree_node *node2 = btree_node_new(btree, node->leaf);
+  if (!node2) {
+    return NULL;
+  }
+  node2->nitems = node->nitems;
+  size_t items_cloned = 0;
+  if (!node2->leaf) {
+    for (size_t i = 0; i < (size_t)(node2->nitems + 1); i++) {
+      node2->children[i] = node->children[i];
+      btree_rc_fetch_add(&node2->children[i]->rc, 1);
+    }
+  }
+  if (btree->item_clone) {
+    for (size_t i = 0; i < node2->nitems; i++) {
+      void *item = btree_get_item_at(btree, node, i);
+      if (!btree->item_clone(item, BTREE_SPARE_NODE, btree->udata)) {
+        goto failed;
+      }
+      btree_set_item_at(btree, node2, i, BTREE_SPARE_NODE);
+      items_cloned++;
+    }
+  } else {
+    for (size_t i = 0; i < node2->nitems; i++) {
+      void *item = btree_get_item_at(btree, node, i);
+      btree_set_item_at(btree, node2, i, item);
+    }
+  }
+  return node2;
+failed:
+  if (!node2->leaf) {
+    for (size_t i = 0; i < (size_t)(node2->nitems + 1); i++) {
+      btree_rc_fetch_sub(&node2->children[i]->rc, 1);
+    }
+  }
+  if (btree->item_free) {
+    for (size_t i = 0; i < items_cloned; i++) {
+      void *item = btree_get_item_at(btree, node2, i);
+      btree->item_free(item, btree->udata);
+    }
+  }
+  btree->free(node2);
+  return NULL;
+}
+
+#define btree_cow_node_or(bnode, code)                            \
+  {                                                               \
+    if (btree_rc_load(&(bnode)->rc) > 0) {                        \
+      struct btree_node *node2 = btree_node_copy(btree, (bnode)); \
+      if (!node2) {                                               \
+        code;                                                     \
+      }                                                           \
+      btree_node_free(btree, bnode);                              \
+      (bnode) = node2;                                            \
+    }                                                             \
+  }
+
+BTREE_EXTERN
+void btree_clear(struct btree *btree) {
+  if (btree->root) {
+    btree_node_free(btree, btree->root);
+  }
+  btree->oom = false;
+  btree->root = NULL;
+  btree->count = 0;
+  btree->height = 0;
+}
+
+BTREE_EXTERN
+void btree_free(struct btree *btree) {
+  btree_clear(btree);
+  btree->free(btree);
+}
+
+BTREE_EXTERN
+void btree_set_item_callbacks(struct btree *btree,
+                              bool (*clone)(const void *item, void *into, void *udata),
+                              void (*free)(const void *item, void *udata)) {
+  btree->item_clone = clone;
+  btree->item_free = free;
+}
+
+BTREE_EXTERN
+struct btree *btree_clone(struct btree *btree) {
+  if (!btree) {
+    return NULL;
+  }
+  size_t size = btree_memsize(btree->elsize, NULL);
+  struct btree *btree2 = btree->malloc(size);
+  if (!btree2) {
+    return NULL;
+  }
+  memcpy(btree2, btree, size);
+  if (btree2->root) btree_rc_fetch_add(&btree2->root->rc, 1);
+  return btree2;
+}
+
+static size_t btree_search(const struct btree *btree, struct btree_node *node, const void *key,
+                           bool *found, uint64_t *hint, int depth) {
+  if (!hint && !btree->searcher) {
+    return btree_node_bsearch(btree, node, key, found);
+  }
+  if (btree->searcher) {
+    return btree->searcher(node->items, node->nitems, key, found, btree->udata);
+  }
+  return btree_node_bsearch_hint(btree, node, key, found, hint, depth);
+}
+
+enum btree_mut_result {
+  BTREE_NOCHANGE,
+  BTREE_NOMEM,
+  BTREE_MUST_SPLIT,
+  BTREE_INSERTED,
+  BTREE_REPLACED,
+  BTREE_DELETED,
+};
+
+static void btree_node_split(struct btree *btree, struct btree_node *node,
+                             struct btree_node **right, void **median) {
+  *right = btree_node_new(btree, node->leaf);
+  if (!*right) {
+    return;  // NOMEM
+  }
+  size_t mid = btree->max_items / 2;
+  *median = btree_get_item_at(btree, node, mid);
+  (*right)->leaf = node->leaf;
+  (*right)->nitems = node->nitems - (mid + 1);
+  memmove((*right)->items, node->items + btree->elsize * (mid + 1),
+          (*right)->nitems * btree->elsize);
+  if (!node->leaf) {
+    for (size_t i = 0; i <= (*right)->nitems; i++) {
+      (*right)->children[i] = node->children[mid + 1 + i];
+    }
+  }
+  node->nitems = mid;
+}
+
+static enum btree_mut_result btree_node_set(struct btree *btree, struct btree_node *node,
+                                            const void *item, uint64_t *hint, int depth) {
+  bool found = false;
+  size_t i = btree_search(btree, node, item, &found, hint, depth);
+  if (found) {
+    btree_swap_item_at(btree, node, i, item, BTREE_SPARE_RETURN);
+    return BTREE_REPLACED;
+  }
+  if (node->leaf) {
+    if (node->nitems == btree->max_items) {
+      return BTREE_MUST_SPLIT;
+    }
+    btree_node_shift_right(btree, node, i);
+    btree_set_item_at(btree, node, i, item);
+    return BTREE_INSERTED;
+  }
+  btree_cow_node_or(node->children[i], return BTREE_NOMEM);
+  enum btree_mut_result result = btree_node_set(btree, node->children[i], item, hint, depth + 1);
+  if (result == BTREE_INSERTED || result == BTREE_REPLACED) {
+    return result;
+  } else if (result == BTREE_NOMEM) {
+    return BTREE_NOMEM;
+  }
+  // Split the child node
+  if (node->nitems == btree->max_items) {
+    return BTREE_MUST_SPLIT;
+  }
+  void *median = NULL;
+  struct btree_node *right = NULL;
+  btree_node_split(btree, node->children[i], &right, &median);
+  if (!right) {
+    return BTREE_NOMEM;
+  }
+  btree_node_shift_right(btree, node, i);
+  btree_set_item_at(btree, node, i, median);
+  node->children[i + 1] = right;
+  return btree_node_set(btree, node, item, hint, depth);
+}
+
+static void *btree_set0(struct btree *btree, const void *item, uint64_t *hint, bool no_item_clone) {
+  btree->oom = false;
+  bool item_cloned = false;
+  if (btree->item_clone && !no_item_clone) {
+    if (!btree->item_clone(item, BTREE_SPARE_CLONE, btree->udata)) {
+      goto oom;
+    }
+    item = BTREE_SPARE_CLONE;
+    item_cloned = true;
+  }
+  if (!btree->root) {
+    btree->root = btree_node_new(btree, true);
+    if (!btree->root) {
+      goto oom;
+    }
+    btree_set_item_at(btree, btree->root, 0, item);
+    btree->root->nitems = 1;
+    btree->count++;
+    btree->height++;
+    return NULL;
+  }
+  btree_cow_node_or(btree->root, goto oom);
+  enum btree_mut_result result;
+set:
+  result = btree_node_set(btree, btree->root, item, hint, 0);
+  if (result == BTREE_REPLACED) {
+    if (btree->item_free) {
+      btree->item_free(BTREE_SPARE_RETURN, btree->udata);
+    }
+    return BTREE_SPARE_RETURN;
+  } else if (result == BTREE_INSERTED) {
+    btree->count++;
+    return NULL;
+  } else if (result == BTREE_NOMEM) {
+    goto oom;
+  }
+  void *old_root = btree->root;
+  struct btree_node *new_root = btree_node_new(btree, false);
+  if (!new_root) {
+    goto oom;
+  }
+  struct btree_node *right = NULL;
+  void *median = NULL;
+  btree_node_split(btree, old_root, &right, &median);
+  if (!right) {
+    btree->free(new_root);
+    goto oom;
+  }
+  btree->root = new_root;
+  btree->root->children[0] = old_root;
+  btree_set_item_at(btree, btree->root, 0, median);
+  btree->root->children[1] = right;
+  btree->root->nitems = 1;
+  btree->height++;
+  goto set;
+oom:
+  if (btree->item_free) {
+    if (item_cloned) {
+      btree->item_free(BTREE_SPARE_CLONE, btree->udata);
+    }
+  }
+  btree->oom = true;
+  return NULL;
+}
+
+static const void *btree_get0(const struct btree *btree, const void *key, uint64_t *hint) {
+  struct btree_node *node = btree->root;
+  if (!node) {
+    return NULL;
+  }
+  bool found;
+  int depth = 0;
+  while (1) {
+    size_t i = btree_search(btree, node, key, &found, hint, depth);
+    if (found) {
+      return btree_get_item_at((void *)btree, node, i);
+    }
+    if (node->leaf) {
+      return NULL;
+    }
+    node = node->children[i];
+    depth++;
+  }
+}
+
+static void btree_node_rebalance(struct btree *btree, struct btree_node *node, size_t i) {
+  if (i == node->nitems) {
+    i--;
+  }
+
+  struct btree_node *left = node->children[i];
+  struct btree_node *right = node->children[i + 1];
+
+  // assert(btree_rc_load(&left->rc)==0);
+  // assert(btree_rc_load(&right->rc)==0);
+
+  if (left->nitems + right->nitems < btree->max_items) {
+    // Merges the left and right children nodes together as a single node
+    // that includes (left,item,right), and places the contents into the
+    // existing left node. Delete the right node altogether and move the
+    // following items and child nodes to the left by one slot.
+
+    // merge (left,item,right)
+    btree_copy_item(btree, left, left->nitems, node, i);
+    left->nitems++;
+    btree_node_join(btree, left, right);
+    btree->free(right);
+    btree_node_shift_left(btree, node, i, true);
+  } else if (left->nitems > right->nitems) {
+    // move left -> right over one slot
+
+    // Move the item of the parent node at index into the right-node first
+    // slot, and move the left-node last item into the previously moved
+    // parent item slot.
+    btree_node_shift_right(btree, right, 0);
+    btree_copy_item(btree, right, 0, node, i);
+    if (!left->leaf) {
+      right->children[0] = left->children[left->nitems];
+    }
+    btree_copy_item(btree, node, i, left, left->nitems - 1);
+    if (!left->leaf) {
+      left->children[left->nitems] = NULL;
+    }
+    left->nitems--;
+  } else {
+    // move right -> left
+
+    // Same as above but the other direction
+    btree_copy_item(btree, left, left->nitems, node, i);
+    if (!left->leaf) {
+      left->children[left->nitems + 1] = right->children[0];
+    }
+    left->nitems++;
+    btree_copy_item(btree, node, i, right, 0);
+    btree_node_shift_left(btree, right, 0, false);
+  }
+}
+
+static enum btree_mut_result btree_node_delete(struct btree *btree, struct btree_node *node,
+                                               enum btree_delact act, size_t index, const void *key,
+                                               void *prev, uint64_t *hint, int depth) {
+  size_t i = 0;
+  bool found = false;
+  if (act == BTREE_DELKEY) {
+    i = btree_search(btree, node, key, &found, hint, depth);
+  } else if (act == BTREE_POPMAX) {
+    i = node->nitems - 1;
+    found = true;
+  } else if (act == BTREE_POPFRONT) {
+    i = 0;
+    found = node->leaf;
+  } else if (act == BTREE_POPBACK) {
+    if (!node->leaf) {
+      i = node->nitems;
+      found = false;
+    } else {
+      i = node->nitems - 1;
+      found = true;
+    }
+  }
+  if (node->leaf) {
+    if (found) {
+      // Item was found in leaf, copy its contents and delete it.
+      // This might cause the number of items to drop below min_items,
+      // and it so, the caller will take care of the rebalancing.
+      btree_copy_item_into(btree, node, i, prev);
+      btree_node_shift_left(btree, node, i, false);
+      return BTREE_DELETED;
+    }
+    return BTREE_NOCHANGE;
+  }
+  enum btree_mut_result result;
+  if (found) {
+    if (act == BTREE_POPMAX) {
+      // Popping off the max item into into its parent branch to maintain
+      // a balanced tree.
+      i++;
+      btree_cow_node_or(node->children[i], return BTREE_NOMEM);
+      btree_cow_node_or(node->children[i == node->nitems ? i - 1 : i + 1], return BTREE_NOMEM);
+      result =
+          btree_node_delete(btree, node->children[i], BTREE_POPMAX, 0, NULL, prev, hint, depth + 1);
+      if (result == BTREE_NOMEM) {
+        return BTREE_NOMEM;
+      }
+      result = BTREE_DELETED;
+    } else {
+      // item was found in branch, copy its contents, delete it, and
+      // begin popping off the max items in child nodes.
+      btree_copy_item_into(btree, node, i, prev);
+      btree_cow_node_or(node->children[i], return BTREE_NOMEM);
+      btree_cow_node_or(node->children[i == node->nitems ? i - 1 : i + 1], return BTREE_NOMEM);
+      result = btree_node_delete(btree, node->children[i], BTREE_POPMAX, 0, NULL,
+                                 BTREE_SPARE_POPMAX, hint, depth + 1);
+      if (result == BTREE_NOMEM) {
+        return BTREE_NOMEM;
+      }
+      btree_set_item_at(btree, node, i, BTREE_SPARE_POPMAX);
+      result = BTREE_DELETED;
+    }
+  } else {
+    // item was not found in this branch, keep searching.
+    btree_cow_node_or(node->children[i], return BTREE_NOMEM);
+    btree_cow_node_or(node->children[i == node->nitems ? i - 1 : i + 1], return BTREE_NOMEM);
+    result = btree_node_delete(btree, node->children[i], act, index, key, prev, hint, depth + 1);
+  }
+  if (result != BTREE_DELETED) {
+    return result;
+  }
+  if (node->children[i]->nitems < btree->min_items) {
+    btree_node_rebalance(btree, node, i);
+  }
+  return BTREE_DELETED;
+}
+
+static void *btree_delete0(struct btree *btree, enum btree_delact act, size_t index,
+                           const void *key, uint64_t *hint) {
+  btree->oom = false;
+  if (!btree->root) {
+    return NULL;
+  }
+  btree_cow_node_or(btree->root, goto oom);
+  enum btree_mut_result result =
+      btree_node_delete(btree, btree->root, act, index, key, BTREE_SPARE_RETURN, hint, 0);
+  if (result == BTREE_NOCHANGE) {
+    return NULL;
+  } else if (result == BTREE_NOMEM) {
+    goto oom;
+  }
+  if (btree->root->nitems == 0) {
+    struct btree_node *old_root = btree->root;
+    if (!btree->root->leaf) {
+      btree->root = btree->root->children[0];
+    } else {
+      btree->root = NULL;
+    }
+    btree->free(old_root);
+    btree->height--;
+  }
+  btree->count--;
+  if (btree->item_free) {
+    btree->item_free(BTREE_SPARE_RETURN, btree->udata);
+  }
+  return BTREE_SPARE_RETURN;
+oom:
+  btree->oom = true;
+  return NULL;
+}
+
+BTREE_EXTERN
+const void *btree_set_hint(struct btree *btree, const void *item, uint64_t *hint) {
+  return btree_set0(btree, item, hint, false);
+}
+
+BTREE_EXTERN
+const void *btree_set(struct btree *btree, const void *item) {
+  return btree_set0(btree, item, NULL, false);
+}
+
+BTREE_EXTERN
+const void *btree_get_hint(const struct btree *btree, const void *key, uint64_t *hint) {
+  return btree_get0(btree, key, hint);
+}
+
+BTREE_EXTERN
+const void *btree_get(const struct btree *btree, const void *key) {
+  return btree_get0(btree, key, NULL);
+}
+
+BTREE_EXTERN
+const void *btree_delete_hint(struct btree *btree, const void *key, uint64_t *hint) {
+  return btree_delete0(btree, BTREE_DELKEY, 0, key, hint);
+}
+
+BTREE_EXTERN
+const void *btree_delete(struct btree *btree, const void *key) {
+  return btree_delete0(btree, BTREE_DELKEY, 0, key, NULL);
+}
+
+BTREE_EXTERN
+const void *btree_pop_min(struct btree *btree) {
+  btree->oom = false;
+  if (btree->root) {
+    btree_cow_node_or(btree->root, goto oom);
+    struct btree_node *node = btree->root;
+    while (1) {
+      if (node->leaf) {
+        if (node->nitems > btree->min_items) {
+          size_t i = 0;
+          btree_copy_item_into(btree, node, i, BTREE_SPARE_RETURN);
+          btree_node_shift_left(btree, node, i, false);
+          if (btree->item_free) {
+            btree->item_free(BTREE_SPARE_RETURN, btree->udata);
+          }
+          btree->count--;
+          return BTREE_SPARE_RETURN;
+        }
+        break;
+      }
+      btree_cow_node_or(node->children[0], goto oom);
+      node = node->children[0];
+    }
+  }
+  return btree_delete0(btree, BTREE_POPFRONT, 0, NULL, NULL);
+oom:
+  btree->oom = true;
+  return NULL;
+}
+
+BTREE_EXTERN
+const void *btree_pop_max(struct btree *btree) {
+  btree->oom = false;
+  if (btree->root) {
+    btree_cow_node_or(btree->root, goto oom);
+    struct btree_node *node = btree->root;
+    while (1) {
+      if (node->leaf) {
+        if (node->nitems > btree->min_items) {
+          size_t i = node->nitems - 1;
+          btree_copy_item_into(btree, node, i, BTREE_SPARE_RETURN);
+          node->nitems--;
+          if (btree->item_free) {
+            btree->item_free(BTREE_SPARE_RETURN, btree->udata);
+          }
+          btree->count--;
+          return BTREE_SPARE_RETURN;
+        }
+        break;
+      }
+      btree_cow_node_or(node->children[node->nitems], goto oom);
+      node = node->children[node->nitems];
+    }
+  }
+  return btree_delete0(btree, BTREE_POPBACK, 0, NULL, NULL);
+oom:
+  btree->oom = true;
+  return NULL;
+}
+
+BTREE_EXTERN
+bool btree_oom(const struct btree *btree) { return !btree || btree->oom; }
+
+BTREE_EXTERN
+size_t btree_count(const struct btree *btree) { return btree->count; }
+
+BTREE_EXTERN
+int btree_compare(const struct btree *btree, const void *a, const void *b) {
+  return _btree_compare(btree, a, b);
+}
+
+static bool btree_node_scan(const struct btree *btree, struct btree_node *node,
+                            bool (*iter)(const void *item, void *udata), void *udata) {
+  if (node->leaf) {
+    for (size_t i = 0; i < node->nitems; i++) {
+      if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  for (size_t i = 0; i < node->nitems; i++) {
+    if (!btree_node_scan(btree, node->children[i], iter, udata)) {
+      return false;
+    }
+    if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+      return false;
+    }
+  }
+  return btree_node_scan(btree, node->children[node->nitems], iter, udata);
+}
+
+static bool btree_node_ascend(const struct btree *btree, struct btree_node *node, const void *pivot,
+                              bool (*iter)(const void *item, void *udata), void *udata,
+                              uint64_t *hint, int depth) {
+  bool found;
+  size_t i = btree_search(btree, node, pivot, &found, hint, depth);
+  if (!found) {
+    if (!node->leaf) {
+      if (!btree_node_ascend(btree, node->children[i], pivot, iter, udata, hint, depth + 1)) {
+        return false;
+      }
+    }
+  }
+  for (; i < node->nitems; i++) {
+    if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+      return false;
+    }
+    if (!node->leaf) {
+      if (!btree_node_scan(btree, node->children[i + 1], iter, udata)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_ascend_hint(const struct btree *btree, const void *pivot,
+                       bool (*iter)(const void *item, void *udata), void *udata, uint64_t *hint) {
+  if (btree->root) {
+    if (!pivot) {
+      return btree_node_scan(btree, btree->root, iter, udata);
+    }
+    return btree_node_ascend(btree, btree->root, pivot, iter, udata, hint, 0);
+  }
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_ascend(const struct btree *btree, const void *pivot,
+                  bool (*iter)(const void *item, void *udata), void *udata) {
+  return btree_ascend_hint(btree, pivot, iter, udata, NULL);
+}
+
+static bool btree_node_reverse(const struct btree *btree, struct btree_node *node,
+                               bool (*iter)(const void *item, void *udata), void *udata) {
+  if (node->leaf) {
+    size_t i = node->nitems - 1;
+    while (1) {
+      if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+        return false;
+      }
+      if (i == 0) break;
+      i--;
+    }
+    return true;
+  }
+  if (!btree_node_reverse(btree, node->children[node->nitems], iter, udata)) {
+    return false;
+  }
+  size_t i = node->nitems - 1;
+  while (1) {
+    if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+      return false;
+    }
+    if (!btree_node_reverse(btree, node->children[i], iter, udata)) {
+      return false;
+    }
+    if (i == 0) break;
+    i--;
+  }
+  return true;
+}
+
+static bool btree_node_descend(const struct btree *btree, struct btree_node *node,
+                               const void *pivot, bool (*iter)(const void *item, void *udata),
+                               void *udata, uint64_t *hint, int depth) {
+  bool found;
+  size_t i = btree_search(btree, node, pivot, &found, hint, depth);
+  if (!found) {
+    if (!node->leaf) {
+      if (!btree_node_descend(btree, node->children[i], pivot, iter, udata, hint, depth + 1)) {
+        return false;
+      }
+    }
+    if (i == 0) {
+      return true;
+    }
+    i--;
+  }
+  while (1) {
+    if (!iter(btree_get_item_at((void *)btree, node, i), udata)) {
+      return false;
+    }
+    if (!node->leaf) {
+      if (!btree_node_reverse(btree, node->children[i], iter, udata)) {
+        return false;
+      }
+    }
+    if (i == 0) break;
+    i--;
+  }
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_descend_hint(const struct btree *btree, const void *pivot,
+                        bool (*iter)(const void *item, void *udata), void *udata, uint64_t *hint) {
+  if (btree->root) {
+    if (!pivot) {
+      return btree_node_reverse(btree, btree->root, iter, udata);
+    }
+    return btree_node_descend(btree, btree->root, pivot, iter, udata, hint, 0);
+  }
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_descend(const struct btree *btree, const void *pivot,
+                   bool (*iter)(const void *item, void *udata), void *udata) {
+  return btree_descend_hint(btree, pivot, iter, udata, NULL);
+}
+
+BTREE_EXTERN
+const void *btree_min(const struct btree *btree) {
+  struct btree_node *node = btree->root;
+  if (!node) {
+    return NULL;
+  }
+  while (1) {
+    if (node->leaf) {
+      return btree_get_item_at((void *)btree, node, 0);
+    }
+    node = node->children[0];
+  }
+}
+
+BTREE_EXTERN
+const void *btree_max(const struct btree *btree) {
+  struct btree_node *node = btree->root;
+  if (!node) {
+    return NULL;
+  }
+  while (1) {
+    if (node->leaf) {
+      return btree_get_item_at((void *)btree, node, node->nitems - 1);
+    }
+    node = node->children[node->nitems];
+  }
+}
+
+BTREE_EXTERN
+const void *btree_load(struct btree *btree, const void *item) {
+  btree->oom = false;
+  if (!btree->root) {
+    return btree_set0(btree, item, NULL, false);
+  }
+  bool item_cloned = false;
+  if (btree->item_clone) {
+    if (!btree->item_clone(item, BTREE_SPARE_CLONE, btree->udata)) {
+      goto oom;
+    }
+    item = BTREE_SPARE_CLONE;
+    item_cloned = true;
+  }
+  btree_cow_node_or(btree->root, goto oom);
+  struct btree_node *node = btree->root;
+  while (1) {
+    if (node->leaf) {
+      if (node->nitems == btree->max_items) break;
+      void *litem = btree_get_item_at(btree, node, node->nitems - 1);
+      if (_btree_compare(btree, item, litem) <= 0) break;
+      btree_set_item_at(btree, node, node->nitems, item);
+      node->nitems++;
+      btree->count++;
+      return NULL;
+    }
+    btree_cow_node_or(node->children[node->nitems], goto oom);
+    node = node->children[node->nitems];
+  }
+  const void *prev = btree_set0(btree, item, NULL, true);
+  if (!btree->oom) {
+    return prev;
+  }
+oom:
+  if (btree->item_free && item_cloned) {
+    btree->item_free(BTREE_SPARE_CLONE, btree->udata);
+  }
+  btree->oom = true;
+  return NULL;
+}
+
+BTREE_EXTERN
+size_t btree_height(const struct btree *btree) { return btree->height; }
+
+struct btree_iter_stack_item {
+  struct btree_node *node;
+  int index;
+};
+
+struct btree_iter {
+  struct btree *btree;
+  void *item;
+  bool seeked;
+  bool atstart;
+  bool atend;
+  int nstack;
+  struct btree_iter_stack_item stack[];
+};
+
+BTREE_EXTERN
+struct btree_iter *btree_iter_new(const struct btree *btree) {
+  size_t vsize = btree_align_size(sizeof(struct btree_iter) +
+                                  sizeof(struct btree_iter_stack_item) * btree->height);
+  struct btree_iter *iter = btree->malloc(vsize + btree->elsize);
+  if (iter) {
+    memset(iter, 0, vsize + btree->elsize);
+    iter->btree = (void *)btree;
+    iter->item = (void *)((char *)iter + vsize);
+  }
+  return iter;
+}
+
+BTREE_EXTERN
+void btree_iter_free(struct btree_iter *iter) { iter->btree->free(iter); }
+
+BTREE_EXTERN
+bool btree_iter_first(struct btree_iter *iter) {
+  iter->atend = false;
+  iter->atstart = false;
+  iter->seeked = false;
+  iter->nstack = 0;
+  if (!iter->btree->root) {
+    return false;
+  }
+  iter->seeked = true;
+  struct btree_node *node = iter->btree->root;
+  while (1) {
+    iter->stack[iter->nstack++] = (struct btree_iter_stack_item){
+        .node = node,
+        .index = 0,
+    };
+    if (node->leaf) {
+      break;
+    }
+    node = node->children[0];
+  }
+  struct btree_iter_stack_item *stack = &iter->stack[iter->nstack - 1];
+  btree_copy_item_into(iter->btree, stack->node, stack->index, iter->item);
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_iter_last(struct btree_iter *iter) {
+  iter->atend = false;
+  iter->atstart = false;
+  iter->seeked = false;
+  iter->nstack = 0;
+  if (!iter->btree->root) {
+    return false;
+  }
+  iter->seeked = true;
+  struct btree_node *node = iter->btree->root;
+  while (1) {
+    iter->stack[iter->nstack++] = (struct btree_iter_stack_item){
+        .node = node,
+        .index = node->nitems,
+    };
+    if (node->leaf) {
+      iter->stack[iter->nstack - 1].index--;
+      break;
+    }
+    node = node->children[node->nitems];
+  }
+  struct btree_iter_stack_item *stack = &iter->stack[iter->nstack - 1];
+  btree_copy_item_into(iter->btree, stack->node, stack->index, iter->item);
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_iter_next(struct btree_iter *iter) {
+  if (!iter->seeked) {
+    return btree_iter_first(iter);
+  }
+  struct btree_iter_stack_item *stack = &iter->stack[iter->nstack - 1];
+  stack->index++;
+  if (stack->node->leaf) {
+    if (stack->index == stack->node->nitems) {
+      while (1) {
+        iter->nstack--;
+        if (iter->nstack == 0) {
+          iter->atend = true;
+          return false;
+        }
+        stack = &iter->stack[iter->nstack - 1];
+        if (stack->index < stack->node->nitems) {
+          break;
+        }
+      }
+    }
+  } else {
+    struct btree_node *node = stack->node->children[stack->index];
+    while (1) {
+      iter->stack[iter->nstack++] = (struct btree_iter_stack_item){
+          .node = node,
+          .index = 0,
+      };
+      if (node->leaf) {
+        break;
+      }
+      node = node->children[0];
+    }
+  }
+  stack = &iter->stack[iter->nstack - 1];
+  btree_copy_item_into(iter->btree, stack->node, stack->index, iter->item);
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_iter_prev(struct btree_iter *iter) {
+  if (!iter->seeked) {
+    return false;
+  }
+  struct btree_iter_stack_item *stack = &iter->stack[iter->nstack - 1];
+  if (stack->node->leaf) {
+    stack->index--;
+    if (stack->index == -1) {
+      while (1) {
+        iter->nstack--;
+        if (iter->nstack == 0) {
+          iter->atstart = true;
+          return false;
+        }
+        stack = &iter->stack[iter->nstack - 1];
+        stack->index--;
+        if (stack->index > -1) {
+          break;
+        }
+      }
+    }
+  } else {
+    struct btree_node *node = stack->node->children[stack->index];
+    while (1) {
+      iter->stack[iter->nstack++] = (struct btree_iter_stack_item){
+          .node = node,
+          .index = node->nitems,
+      };
+      if (node->leaf) {
+        iter->stack[iter->nstack - 1].index--;
+        break;
+      }
+      node = node->children[node->nitems];
+    }
+  }
+  stack = &iter->stack[iter->nstack - 1];
+  btree_copy_item_into(iter->btree, stack->node, stack->index, iter->item);
+  return true;
+}
+
+BTREE_EXTERN
+bool btree_iter_seek(struct btree_iter *iter, const void *key) {
+  iter->atend = false;
+  iter->atstart = false;
+  iter->seeked = false;
+  iter->nstack = 0;
+  if (!iter->btree->root) {
+    return false;
+  }
+  iter->seeked = true;
+  struct btree_node *node = iter->btree->root;
+  while (1) {
+    bool found;
+    size_t i = btree_node_bsearch(iter->btree, node, key, &found);
+    iter->stack[iter->nstack++] = (struct btree_iter_stack_item){
+        .node = node,
+        .index = i,
+    };
+    if (found) {
+      btree_copy_item_into(iter->btree, node, i, iter->item);
+      return true;
+    }
+    if (node->leaf) {
+      iter->stack[iter->nstack - 1].index--;
+      return btree_iter_next(iter);
+    }
+    node = node->children[i];
+  }
+}
+
+BTREE_EXTERN
+const void *btree_iter_item(struct btree_iter *iter) { return iter->item; }
+
+#ifdef BTREE_TEST_PRIVATE_FUNCTIONS
+#include "tests/priv_funcs.h"
+#endif

--- a/src/hotline/btree.h
+++ b/src/hotline/btree.h
@@ -1,0 +1,210 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2020 Joshua J Baker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+*/
+
+// Copyright 2020 Joshua J Baker. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+#ifndef BTREE_H
+#define BTREE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct btree;
+
+// btree_new returns a new B-tree.
+//
+// Param elsize is the size of each element in the tree. Every element that
+// is inserted, deleted, or searched will be this size.
+// Param max_items is the maximum number of items per node. Setting this to
+// zero will default to 256.
+// Param compare is a function that compares items in the tree. See the
+// qsort stdlib function for an example of how this function works.
+// Param udata is user-defined data that is passed to the compare callback
+// and the item callbacks defined in btree_set_item_callbacks.
+//
+// The btree must be freed with btree_free().
+struct btree *btree_new(size_t elsize, size_t max_items,
+                        int (*compare)(const void *a, const void *b, void *udata), void *udata);
+
+// btree_new_with_allocator returns a new btree using a custom allocator.
+//
+// See btree_new for more information
+struct btree *btree_new_with_allocator(void *(*malloc)(size_t), void *(*realloc)(void *, size_t),
+                                       void (*free)(void *), size_t elsize, size_t max_items,
+                                       int (*compare)(const void *a, const void *b, void *udata),
+                                       void *udata);
+
+// btree_set_item_callbacks sets the item clone and free callbacks that will be
+// called internally by the btree when items are inserted and removed.
+//
+// These callbacks are optional but may be needed by programs that require
+// copy-on-write support by using the btree_clone function.
+//
+// The clone function should return true if the clone succeeded or false if the
+// system is out of memory.
+void btree_set_item_callbacks(struct btree *btree,
+                              bool (*clone)(const void *item, void *into, void *udata),
+                              void (*free)(const void *item, void *udata));
+
+// btree_free removes all items from the btree and frees any allocated memory.
+void btree_free(struct btree *btree);
+
+// btree_free removes all items from the btree.
+void btree_clear(struct btree *btree);
+
+// btree_oom returns true if the last write operation failed because the system
+// has no more memory available.
+//
+// Functions that have the first param being a non-const btree receiver are
+// candidates for possible out-of-memory conditions, such as btree_set,
+// btree_delete, btree_load, etc.
+bool btree_oom(const struct btree *btree);
+
+// btree_height returns the height of the btree from root to leaf or zero if
+// the btree is empty.
+size_t btree_height(const struct btree *btree);
+
+// btree_count returns the number of items in the btree.
+size_t btree_count(const struct btree *btree);
+
+// btree_clone makes an instant copy of the btree.
+// This operation uses shadowing / copy-on-write.
+struct btree *btree_clone(struct btree *btree);
+
+// btree_set inserts or replaces an item in the btree. If an item is replaced
+// then it is returned otherwise NULL is returned.
+//
+// If the system fails allocate the memory needed then NULL is returned
+// and btree_oom() returns true.
+const void *btree_set(struct btree *btree, const void *item);
+
+// btree_delete removes an item from the B-tree and returns it.
+//
+// Returns NULL if item not found.
+// This operation may trigger node copies if the btree was cloned using
+// btree_clone.
+// If the system fails allocate the memory needed then NULL is returned
+// and btree_oom() returns true.
+const void *btree_delete(struct btree *btree, const void *key);
+
+// btree_load is the same as btree_set but is optimized for sequential bulk
+// loading. It can be up to 10x faster than btree_set when the items are
+// in exact order, but up to 25% slower when not in exact order.
+//
+// If the system fails allocate the memory needed then NULL is returned
+// and btree_oom() returns true.
+const void *btree_load(struct btree *btree, const void *item);
+
+// btree_pop_min removes the first item in the btree and returns it.
+//
+// Returns NULL if btree is empty.
+// This operation may trigger node copies if the btree was cloned using
+// btree_clone.
+// If the system fails allocate the memory needed then NULL is returned
+// and btree_oom() returns true.
+const void *btree_pop_min(struct btree *btree);
+
+// btree_pop_min removes the last item in the btree and returns it.
+//
+// Returns NULL if btree is empty.
+// This operation may trigger node copies if the btree was cloned using
+// btree_clone.
+// If the system fails allocate the memory needed then NULL is returned
+// and btree_oom() returns true.
+const void *btree_pop_max(struct btree *btree);
+
+// btree_pop_min returns the first item in the btree or NULL if btree is empty.
+const void *btree_min(const struct btree *btree);
+
+// btree_pop_min returns the last item in the btree or NULL if btree is empty.
+const void *btree_max(const struct btree *btree);
+
+// btree_get returns the item based on the provided key.
+//
+// Returns NULL if item is not found.
+const void *btree_get(const struct btree *btree, const void *key);
+
+// btree_ascend scans the tree within the range [pivot, last].
+//
+// In other words btree_ascend iterates over all items that are
+// greater-than-or-equal-to pivot in ascending order.
+//
+// Param pivot can be NULL, which means all items are iterated over.
+// Param iter can return false to stop iteration early.
+// Returns false if the iteration has been stopped early.
+bool btree_ascend(const struct btree *btree, const void *pivot,
+                  bool (*iter)(const void *item, void *udata), void *udata);
+
+// btree_descend scans the tree within the range [pivot, first].
+
+// In other words btree_descend() iterates over all items that are
+// less-than-or-equal-to pivot in descending order.
+//
+// Param pivot can be NULL, which means all items are iterated over.
+// Param iter can return false to stop iteration early.
+// Returns false if the iteration has been stopped early.
+bool btree_descend(const struct btree *btree, const void *pivot,
+                   bool (*iter)(const void *item, void *udata), void *udata);
+
+// btree_set_hint is the same as btree_set except that an optional "hint" can
+// be provided which may make the operation quicker when done as a batch or
+// in a userspace context.
+const void *btree_set_hint(struct btree *btree, const void *item, uint64_t *hint);
+
+// btree_get_hint is the same as btree_get except that an optional "hint" can
+// be provided which may make the operation quicker when done as a batch or
+// in a userspace context.
+const void *btree_get_hint(const struct btree *btree, const void *key, uint64_t *hint);
+
+// btree_delete_hint is the same as btree_delete except that an optional "hint"
+// can be provided which may make the operation quicker when done as a batch or
+// in a userspace context.
+const void *btree_delete_hint(struct btree *btree, const void *key, uint64_t *hint);
+
+// btree_ascend_hint is the same as btree_ascend except that an optional
+// "hint" can be provided which may make the operation quicker when done as a
+// batch or in a userspace context.
+bool btree_ascend_hint(const struct btree *btree, const void *pivot,
+                       bool (*iter)(const void *item, void *udata), void *udata, uint64_t *hint);
+
+// btree_descend_hint is the same as btree_descend except that an optional
+// "hint" can be provided which may make the operation quicker when done as a
+// batch or in a userspace context.
+bool btree_descend_hint(const struct btree *btree, const void *pivot,
+                        bool (*iter)(const void *item, void *udata), void *udata, uint64_t *hint);
+
+// btree_set_searcher allows for setting a custom search function.
+void btree_set_searcher(struct btree *btree,
+                        int (*searcher)(const void *items, size_t nitems, const void *key,
+                                        bool *found, void *udata));
+
+// Loop-based iterator
+struct btree_iter *btree_iter_new(const struct btree *btree);
+void btree_iter_free(struct btree_iter *iter);
+bool btree_iter_first(struct btree_iter *iter);
+bool btree_iter_last(struct btree_iter *iter);
+bool btree_iter_next(struct btree_iter *iter);
+bool btree_iter_prev(struct btree_iter *iter);
+bool btree_iter_seek(struct btree_iter *iter, const void *key);
+const void *btree_iter_item(struct btree_iter *iter);
+
+// DEPRECATED: use `btree_new_with_allocator`
+void btree_set_allocator(void *(malloc)(size_t), void (*free)(void *));
+
+#endif

--- a/src/hotline/config.c
+++ b/src/hotline/config.c
@@ -1,0 +1,118 @@
+#include "config.h"
+
+#include <getopt.h>
+#include <inttypes.h>
+#include <math.h>
+#include <string.h>
+
+#include "hotline.h"
+#include "log.h"
+#include "perf_interface.h"
+#include "sys.h"
+
+/// @brief Exposed profile configuration after argument parsing
+profile_config_t profile_configuration;
+
+/// @brief Argument parsing logic for CLI input
+void parse_arguments(int argc, char *argv[]) {
+  static struct option long_options[] = {{"wakeup_period", required_argument, 0, 'p'},
+                                         {"hotline_frequency", required_argument, 0, 's'},
+                                         {"timeout", required_argument, 0, 't'},
+                                         {"data_dir", required_argument, 0, 'd'},
+                                         {"num_to_report", required_argument, 0, 'n'},
+                                         {0, 0, 0, 0}};
+
+  int option_index = 0;
+  int c;
+
+  // Reset getopt
+  optind = 1;
+
+  profile_configuration.wakeup_period = PROFILE_DEFAULT_WAKEUP_PERIOD;
+  profile_configuration.hotline_frequency = PROFILE_DEFAULT_SPE_SAMPLE_FREQ;
+  profile_configuration.timeout = PROFILE_DEFAULT_TIMEOUT;
+  profile_configuration.data_dir = "./data";
+  profile_configuration.bmiss_map_filename = "hotline_bmiss_map.csv";
+  profile_configuration.lat_map_filename = "hotline_lat_map.csv";
+  profile_configuration.num_to_report = PROFILE_DEFAULT_NUM_REPORT;
+
+  while ((c = getopt_long_only(argc, argv, "", long_options, &option_index)) != -1) {
+    switch (c) {
+      case 'p':
+        ASSERT(sscanf(optarg, "%" SCNu32, &profile_configuration.wakeup_period) == 1,
+               "Failed to read wakeup period");
+        break;
+      case 's':
+        ASSERT(sscanf(optarg, "%" SCNu32, &profile_configuration.hotline_frequency) == 1,
+               "Failed to read sample frequency");
+        break;
+      case 't':
+        ASSERT(sscanf(optarg, "%" SCNu32, &profile_configuration.timeout) == 1,
+               "Failed to read timeout");
+        break;
+      case 'd':
+        profile_configuration.data_dir = optarg;
+        break;
+      case 'n':
+        ASSERT(sscanf(optarg, "%" SCNu32, &profile_configuration.num_to_report) == 1,
+               "Failed to read number to report");
+        break;
+      case '?':
+        printf("Unknown option or missing argument\n");
+        printf(
+            "Usage: ./<BINARY> --wakeup_period X --hotline_frequency X "
+            "--timeout X "
+            "--data_dir path\n");
+        exit(EXIT_FAILURE);
+        break;
+      default:
+        printf("Invalid command provided.\n");
+        printf(
+            "Usage: ./<BINARY> --wakeup_period X --hotline_frequency X "
+            "--timeout X "
+            "--data_dir path\n");
+        exit(EXIT_FAILURE);
+    }
+  }
+
+  ASSERT(profile_configuration.wakeup_period > 0, "Wakeup period must be greater than 0.");
+  ASSERT(profile_configuration.hotline_frequency > 0 &&
+             profile_configuration.hotline_frequency <= MAX_SPE_SAMPLE_FREQ,
+         "SPE sample frequency provided is out of range.");
+  ASSERT(profile_configuration.timeout > 0, "Timeout must be greater than 0.");
+}
+
+/// @brief computes the buffer sizes for the record and aux buffers
+/// and returns it in a packaged struct.
+/// @returns perf record buffer size, aux buffer size, and aux offset
+void get_perf_buffer_sizes(perf_buffer_size_t *buffer_sizes) {
+  uint64_t page_sz = cpu_system_config.page_size;
+
+  // independent of sampling period, and hard to
+  // predict due to context switches, so we statically
+  // make it a large amount profiling shows that this
+  // causes an increase in CPU util at the begining of
+  // the tool, during setup, but does not have much of
+  // an impact later onwards. We instead make it only
+  // proportional to the wakeup period
+  uint64_t perf_record_buf_sz = 16 * cpu_system_config.page_size *
+                                sizeof(switch_cpu_wide_record_t) *
+                                profile_configuration.wakeup_period;
+  uint64_t perf_aux_buf_sz = profile_configuration.hotline_frequency *
+                             profile_configuration.wakeup_period * sizeof(spe_record_raw_t) *
+                             4;  // overestimate factor of 4x
+
+  // round it to a power of 2, as
+  // required by perf_event_open docs
+  perf_aux_buf_sz = (uint64_t)pow(2, ceil(log2((double)perf_aux_buf_sz)));
+
+  // round up to it is of the form 1 + 2^n pages
+  perf_record_buf_sz =
+      (uint64_t)pow(2, ceil(log2((double)perf_record_buf_sz))) + cpu_system_config.page_size;
+
+  uint64_t perf_aux_off = perf_record_buf_sz + page_sz;
+
+  buffer_sizes->perf_record_buf_sz = perf_record_buf_sz;
+  buffer_sizes->perf_aux_buf_sz = perf_aux_buf_sz;
+  buffer_sizes->perf_aux_off = perf_aux_off;
+}

--- a/src/hotline/config.h
+++ b/src/hotline/config.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h>
+
+#define PROFILE_DEFAULT_WAKEUP_PERIOD 1       // 1s
+#define PROFILE_DEFAULT_SPE_SAMPLE_FREQ 1000  // 1kHz
+#define PROFILE_DEFAULT_TIMEOUT 10            // 10s
+#define PROFILE_DEFAULT_NUM_REPORT 1000
+#define MAX_SPE_SAMPLE_FREQ 4096  // cycles
+
+/// @brief Global profile configuration. Will be accessed from online data
+/// collection and offline report generation.
+typedef struct profile_config {
+  uint32_t wakeup_period;
+  uint32_t hotline_frequency;
+  uint32_t timeout;
+  uint32_t num_to_report;
+  const char *data_dir;
+  char *bmiss_map_filename;
+  char *lat_map_filename;
+} profile_config_t;
+
+/// @brief Utility struct to package all the buffer sizes together.
+typedef struct perf_buffer_size_t {
+  uint64_t perf_record_buf_sz;
+  uint64_t perf_aux_buf_sz;
+  uint64_t perf_aux_off;
+} perf_buffer_size_t;
+
+void parse_arguments(int argc, char *argv[]);
+
+void get_perf_buffer_sizes(perf_buffer_size_t *buffer_sizes);
+
+extern profile_config_t profile_configuration;

--- a/src/hotline/finode_map.c
+++ b/src/hotline/finode_map.c
@@ -1,0 +1,51 @@
+#include "finode_map.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "log.h"
+
+struct btree *finode_map = NULL;
+
+/// @brief Comparison function for the file inode structures
+/// @param a First finode_map_entry to compare
+/// @param b Second finode_map_entry to compare
+/// @param udata Unused
+/// @return 1 if a > b, -1 if a < b, 0 otherwise
+int finode_compare(const void *a, const void *b, void *udata) {
+  (void)udata;
+  const finode_t *fa = &((const finode_map_entry_t *)a)->finode;
+  const finode_t *fb = &((const finode_map_entry_t *)b)->finode;
+
+  // Compare ino first as it's likely to be unique most often
+  if (fa->ino != fb->ino) return (fa->ino > fb->ino) ? 1 : -1;
+
+  // Then device numbers
+  if (fa->maj != fb->maj) return (fa->maj > fb->maj) ? 1 : -1;
+
+  if (fa->min != fb->min) return (fa->min > fb->min) ? 1 : -1;
+
+  // Finally generation number
+  if (fa->ino_generation != fb->ino_generation)
+    return (fa->ino_generation > fb->ino_generation) ? 1 : -1;
+
+  return 0;
+}
+
+void init_finode_map() {
+  finode_map = btree_new(sizeof(finode_map_entry_t), 0, finode_compare, NULL);
+  btree_clear(finode_map);
+}
+
+void insert_finode_entry(mmap2_record_t *record) {
+  finode_map_entry_t entry;
+  entry.finode.ino = record->ino;
+  entry.finode.maj = record->maj;
+  entry.finode.min = record->min;
+  entry.finode.ino_generation = record->ino_generation;
+
+  entry.filename = strdup(record->filename);
+  btree_set(finode_map, &entry);
+  ASSERT(!btree_oom(finode_map), "Finode-Map OOM.");
+}

--- a/src/hotline/finode_map.h
+++ b/src/hotline/finode_map.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "btree.h"
+#include "perf_interface.h"
+
+/// @brief Utility structure to package all inode information for a file.
+typedef struct finode {
+  uint32_t maj;
+  uint32_t min;
+  uint64_t ino;
+  uint64_t ino_generation;
+} finode_t;
+
+/// @brief B-Tree structure for mapping inode information to a filename. This
+/// was
+///  created to avoid string comparisons in the lat_map and bmiss_map data
+///  structures.
+typedef struct finode_map_entry {
+  finode_t finode;
+  char *filename;
+} finode_map_entry_t;
+
+void init_finode_map();
+void insert_finode_entry(mmap2_record_t *record);
+
+extern struct btree *finode_map;

--- a/src/hotline/fname_binary_map.c
+++ b/src/hotline/fname_binary_map.c
@@ -1,0 +1,416 @@
+#include "fname_binary_map.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+
+#include "log.h"
+
+static const Dwfl_Callbacks callbacks = {
+    .find_elf = dwfl_build_id_find_elf,
+    .find_debuginfo = dwfl_standard_find_debuginfo,
+    .section_address = dwfl_offline_section_address,
+};
+
+struct btree *fname_binary_map = NULL;
+
+/// @brief Comparison function for filename binary mappings
+/// @param a First fname_binary_entry to compare
+/// @param b Second fname_binary_entry to compare
+/// @param udata Unused
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int fname_binary_map_compare(const void *a, const void *b, void *udata) {
+  (void)udata;
+  const fname_binary_map_entry_t *ua = a;
+  const fname_binary_map_entry_t *ub = b;
+
+  return strcmp(ua->filename, ub->filename);
+}
+
+/// @brief Helper function to process ELF sections
+/// @param info Binary info struct to populate with ELF information
+/// @return true if successfully mapped file, false otherwise
+bool process_elf_sections(binary_info_t *info) {
+  for (int i = 0; i < info->ehdr->e_shnum; i++) {
+    char *section_name = info->shstrtab + info->shdr[i].sh_name;
+
+    if (strcmp(section_name, ".text") == 0) {
+      info->text_section = (char *)info->map + info->shdr[i].sh_offset;
+      info->text_addr = info->shdr[i].sh_addr;
+      info->text_size = info->shdr[i].sh_size;
+    } else if (strcmp(section_name, ".symtab") == 0) {
+      info->symtab = (Elf64_Sym *)((char *)info->map + info->shdr[i].sh_offset);
+      info->sym_count = info->shdr[i].sh_size / sizeof(Elf64_Sym);
+    } else if (strcmp(section_name, ".strtab") == 0) {
+      info->strtab = (char *)info->map + info->shdr[i].sh_offset;
+    }
+  }
+  return (info->text_section && info->symtab && info->strtab);
+}
+
+/// @brief Helper function to initialize DWARD debuf info
+/// @param info Debug info struct to populate
+/// @param filename File to populate struct for
+/// @return true if successfully initialized, false otherwise
+bool init_dwarf_info(binary_info_t *info, const char *filename) {
+  info->dwfl = dwfl_begin(&callbacks);
+  if (!info->dwfl) {
+    fprintf(stderr, "Failed to initialize DWARF reader\n");
+    return false;
+  }
+
+  dwfl_report_begin(info->dwfl);
+  Dwfl_Module *module = dwfl_report_elf(info->dwfl, filename, filename, -1, 0, false);
+  dwfl_report_end(info->dwfl, NULL, NULL);
+
+  if (!module) {
+    fprintf(stderr, "Failed to load debug info\n");
+    dwfl_end(info->dwfl);
+    return false;
+  }
+
+  return true;
+}
+
+/// @brief Loads all the information for a binary and returns a pointer to the
+/// struct
+/// @param filename Binary file to load
+/// @return Pointer to populated struct
+binary_info_t *load_binary(const char *filename) {
+  // Allocate and initialize binary info structure
+  binary_info_t *info = malloc(sizeof(binary_info_t));
+  ASSERT(info, "Failed to allocate memory for binary_info_t");
+  memset(info, 0, sizeof(binary_info_t));
+
+  // The following errors are graceful, because we may not always be able to map
+  // a profiled binary bag with debug symbols.
+
+  // Initialize Capstone
+  if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &info->cs_handle) != CS_ERR_OK) {
+    fprintf(stderr, "Failed to initialize Capstone\n");
+    goto cleanup_info;
+  }
+
+  // Open the binary file
+  int fd = open(filename, O_RDONLY);
+  if (fd < 0) {
+    fprintf(stderr, "Non-fatal: Cannot open binary %s\n", filename);
+    goto cleanup_capstone;
+  }
+
+  // Get file size
+  struct stat st;
+  if (fstat(fd, &st) < 0) {
+    fprintf(stderr, "Failed to get file stats\n");
+    goto cleanup_fd;
+  }
+  info->size = st.st_size;
+
+  // Map file into memory
+  info->map = mmap(NULL, info->size, PROT_READ, MAP_PRIVATE, fd, 0);
+  ASSERT(info->map != MAP_FAILED, "Failed to mmap binary.");
+
+  // Parse ELF header
+  info->ehdr = (Elf64_Ehdr *)info->map;
+
+  // This is a graceful cleanup without an ASSERT because sometimes files like
+  // [vdso] and [stack] show up, and we don't want to crash on them.
+  if (memcmp(info->ehdr->e_ident, ELFMAG, SELFMAG) != 0) {
+    fprintf(stderr, "Not an ELF file\n");
+    goto cleanup_mmap;
+  }
+
+  // Get section headers and string table
+  info->shdr = (Elf64_Shdr *)((char *)info->map + info->ehdr->e_shoff);
+  info->shstrtab = (char *)info->map + info->shdr[info->ehdr->e_shstrndx].sh_offset;
+
+  // These are also graceful cleanups for the same reason. We don't want to
+  // crash the whole program for a single file that may not be traceable back
+  // with debug info. Find and process important sections
+  if (!process_elf_sections(info)) {
+    goto cleanup_mmap;
+  }
+
+  // Initialize DWARF debug info
+  if (!init_dwarf_info(info, filename)) {
+    goto cleanup_mmap;
+  }
+
+  return info;
+
+  // Cleanup handlers
+cleanup_mmap:
+  munmap(info->map, info->size);
+cleanup_fd:
+  close(fd);
+cleanup_capstone:
+  cs_close(&info->cs_handle);
+cleanup_info:
+  free(info);
+  return NULL;
+}
+
+/// @brief Initializes the mapping structure
+void init_fname_binary_btree() {
+  fname_binary_map = btree_new(sizeof(fname_binary_map_entry_t), 0, fname_binary_map_compare, NULL);
+  btree_clear(fname_binary_map);
+}
+
+/// @brief If entry exists, returns it. Otherwise loads the binary and puts it
+/// in.
+/// @param filename Binary to search for
+/// @return Pointer to binary.
+binary_info_t *get_fname_binary_map_entry(char *filename) {
+  fname_binary_map_entry_t fname_entry;
+  fname_entry.filename = filename;
+
+  const fname_binary_map_entry_t *result = btree_get(fname_binary_map, &fname_entry);
+  if (result == NULL) {  // need to load binary now
+    binary_info_t *info = load_binary(filename);
+    fname_entry.binary_info = info;
+    btree_set(fname_binary_map, &fname_entry);
+    return info;
+  } else {
+    return result->binary_info;  // already loaded previously, just recycle
+  }
+}
+
+/// @brief Returns the function associated with the addr
+/// @param info Binary info structure for file
+/// @param addr Offset into file
+/// @return Function name
+char *get_function_name(binary_info_t *info, uint64_t addr) {
+  if (!info || !info->symtab || !info->strtab) return NULL;
+
+  for (int i = 0; i < info->sym_count; i++) {
+    if (ELF64_ST_TYPE(info->symtab[i].st_info) == STT_FUNC) {
+      if (addr >= info->symtab[i].st_value &&
+          addr < info->symtab[i].st_value + info->symtab[i].st_size) {
+        char *name = strdup(info->strtab + info->symtab[i].st_name);
+        ASSERT(name != NULL, "Function name should not be null.");
+        return name;
+      }
+    }
+  }
+  return NULL;
+}
+
+/// @brief Returns the assembly associated with the addr
+/// @param info Binary info structure for file
+/// @param addr Offset into file
+/// @return Assembly code
+char *get_assembly(binary_info_t *info, uint64_t offset) {
+  char *assembly = NULL;
+
+  // Check if offset is in text section
+  if (offset >= info->text_addr && offset < info->text_addr + info->text_size) {
+    uint64_t roffset = offset - info->text_addr;
+    cs_insn *insn;
+    size_t count = cs_disasm(info->cs_handle, (uint8_t *)info->text_section + roffset,
+                             4,  // Read 4 bytes for instruction
+                             offset,
+                             1,  // Disassemble 1 instruction
+                             &insn);
+
+    if (count > 0) {
+      // Allocate and format assembly string
+      size_t len = strlen(insn[0].mnemonic) + strlen(insn[0].op_str) + 2;
+      assembly = malloc(len);
+      ASSERT(assembly != NULL, "Failed to malloc space for assembly string.");
+      if (assembly) {
+        int res = snprintf(assembly, len, "%s %s", insn[0].mnemonic, insn[0].op_str);
+        ASSERT(res > 0, "snprintf failed.");
+
+        // Replace commas with spaces
+        for (char *p = assembly; *p; p++) {
+          if (*p == ',') *p = ' ';
+        }
+      }
+      cs_free(insn, count);
+    }
+  }
+
+  return assembly;
+}
+
+/// @brief Converts a relative path to an absolute path
+/// @param binary_path Location of binary file
+/// @param source_path Location of source *from* binary path
+/// @return Absolute path of source file
+char *get_absolute_source_path(const char *binary_path, const char *source_path) {
+  if (!source_path) {
+    return NULL;
+  }
+
+  // If it's already an absolute path, just return a copy
+  if (source_path[0] == '/') {
+    return strdup(source_path);
+  }
+
+  // For relative paths, resolve against the binary's directory
+  char *binary_dir = strdup(binary_path);
+  char *last_slash = strrchr(binary_dir, '/');
+  if (last_slash) {
+    *(last_slash + 1) = '\0';  // Cut off the filename, keep the slash
+  }
+
+  // Combine paths and resolve
+  size_t full_len = strlen(binary_dir) + strlen(source_path) + 1;
+  char *combined = malloc(full_len);
+  if (!combined) {
+    free(binary_dir);
+    return NULL;
+  }
+
+  int res = snprintf(combined, full_len, "%s%s", binary_dir, source_path);
+  ASSERT(res > 0, "snprintf failed.");
+  free(binary_dir);
+
+  // Use realpath to resolve the absolute path
+  char *absolute = realpath(combined, NULL);
+  free(combined);
+
+  return absolute ? absolute : strdup(source_path);  // Fall back to original if realpath fails
+}
+
+/// @brief Gets the source code file from the binary file and offset
+/// @param binary_path Binary file path
+/// @param info Debug info struct containing the debug info
+/// @param addr Offset into binary file
+/// @return Source file information such as filename and line number
+source_file_info_t *get_source_info(char *binary_path, binary_info_t *info, uint64_t addr) {
+  if (!info || !info->dwfl) {
+    return NULL;
+  }
+
+  Dwfl_Module *module = dwfl_addrmodule(info->dwfl, addr);
+  if (!module) {
+    return NULL;
+  }
+
+  Dwfl_Line *line_info = dwfl_getsrc(info->dwfl, addr);
+  if (!line_info) {
+    return NULL;
+  }
+
+  int line_number;
+  const char *relative_path = dwfl_lineinfo(line_info, NULL, &line_number, NULL, NULL, NULL);
+  if (!relative_path) {
+    return NULL;
+  }
+
+  // Allocate the structure
+  source_file_info_t *source_info = malloc(sizeof(source_file_info_t));
+  if (!source_info) {
+    return NULL;
+  }
+
+  // Get absolute path and store line number
+  source_info->filename = get_absolute_source_path(binary_path, relative_path);
+  if (!source_info->filename) {
+    free(source_info);
+    return NULL;
+  }
+  source_info->line_number = line_number;
+
+  return source_info;
+}
+
+/// @brief Converts a source file and target line into a line of code
+/// @param filename Source filename
+/// @param target_line Line to get code of
+/// @return Line of code at location
+char *get_line_at_line_number(const char *filename, int target_line) {
+  FILE *file = fopen(filename, "r");
+  if (!file) {
+    return NULL;
+  }
+
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t read;
+  int current_line = 1;
+
+  // Skip to target line
+  while (current_line < target_line) {
+    read = getline(&line, &len, file);
+    if (read == -1) {
+      free(line);
+      fclose(file);
+      return NULL;
+    }
+    current_line++;
+  }
+
+  // Read target line
+  read = getline(&line, &len, file);
+  fclose(file);
+
+  if (read == -1) {
+    free(line);
+    return NULL;
+  }
+
+  // Remove newline if present
+  if (read > 0 && line[read - 1] == '\n') {
+    line[read - 1] = '\0';
+  }
+
+  // Allocate new string with space for quotes and null terminator
+  // Add quotes so that in CSV representation commas are not an issue
+  size_t quoted_len = strlen(line) + 3;  // +2 for quotes, +1 for null
+  char *quoted_line = malloc(quoted_len);
+  if (!quoted_line) {
+    free(line);
+    return NULL;
+  }
+
+  int res = snprintf(quoted_line, quoted_len, "\"%s\"", line);
+  ASSERT(res > 0, "snprintf failed.");
+  free(line);
+
+  return quoted_line;
+}
+
+/// @brief Gets all the debug info (function, asm, source file, line number) for
+/// a filename and offset
+/// @param filename Filename to get info of
+/// @param offset Offset into file
+/// @return Populated pointer to debug_info_t struct
+debug_info_t *get_debug_info(char *filename, uint64_t offset) {
+  binary_info_t *info = get_fname_binary_map_entry(filename);
+  debug_info_t *dinfo = malloc(sizeof(debug_info_t));
+  ASSERT(dinfo != NULL, "Failed to create debug info struct.");
+  memset(dinfo, 0, sizeof(debug_info_t));
+
+  if (info) {
+    const source_file_info_t *source = get_source_info(filename, info, offset);
+    if (source) {
+      dinfo->src_file = strdup(source->filename);
+      dinfo->line_num = source->line_number;
+      dinfo->line = get_line_at_line_number(source->filename, source->line_number);
+    } else {
+      dinfo->src_file = strdup("(null)");
+      dinfo->line = strdup("(null)");
+      dinfo->line_num = 0;
+    }
+
+    char *function = get_function_name(info, offset);
+    if (function) {
+      dinfo->function = function;
+    } else {
+      dinfo->function = strdup("(null)");
+    }
+
+    char *assembly = get_assembly(info, offset);
+    if (assembly) {
+      dinfo->assembly = assembly;
+    } else {
+      dinfo->assembly = strdup("(null)");
+    }
+  }
+  return dinfo;
+}

--- a/src/hotline/fname_binary_map.h
+++ b/src/hotline/fname_binary_map.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <capstone/capstone.h>
+#include <dwarf.h>
+#include <elf.h>
+#include <elfutils/libdw.h>
+#include <elfutils/libdwfl.h>
+#include <unistd.h>
+
+#include "btree.h"
+
+/// @brief Open session information for a binary file
+typedef struct binary_info {
+  void *map;
+  size_t size;
+  Elf64_Ehdr *ehdr;
+  Elf64_Shdr *shdr;
+  char *shstrtab;
+  Elf64_Sym *symtab;
+  char *strtab;
+  int sym_count;
+  void *text_section;
+  uint64_t text_addr;
+  size_t text_size;
+  Dwfl *dwfl;
+  csh cs_handle;
+} binary_info_t;
+
+/// @brief There are often many offsets associated with the same file. Setting
+/// up and reading into a file is expensive, so we can first check if we have
+/// already set up this file first by indexing this B-Tree.
+typedef struct fname_binary_map_entry {
+  char *filename;
+  binary_info_t *binary_info;
+} fname_binary_map_entry_t;
+
+typedef struct source_file_info {
+  char *filename;
+  uint64_t line_number;
+} source_file_info_t;
+
+typedef struct debug_info {
+  char *src_file;
+  uint64_t line_num;
+  char *line;
+  char *assembly;
+  char *function;
+} debug_info_t;
+
+void init_fname_binary_btree();
+binary_info_t *get_fname_binary_map_entry(char *filename);
+
+debug_info_t *get_debug_info(char *filename, uint64_t offset);
+
+char *get_absolute_source_path(const char *binary_path, const char *source_path);
+char *get_line_at_line_number(const char *filename, int target_line);

--- a/src/hotline/fname_map.c
+++ b/src/hotline/fname_map.c
@@ -1,0 +1,234 @@
+#include "fname_map.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "log.h"
+#include "sys.h"
+#include "vec.h"
+
+struct btree *fname_map = NULL;
+const filename_entry_t *cached_entry[CACHE_DEPTH] = {NULL};
+
+/// @brief B-Tree compare function for FNAME_MAP structs
+/// @param a First entry to compare
+/// @param b Second entry to compare
+/// @param udata Unused
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int fname_compare(const void *a, const void *b, void *udata) {
+  (void)udata;
+  const filename_entry_t *ua = a;
+  const filename_entry_t *ub = b;
+
+  if (ua->pid < ub->pid) return -1;
+  if (ua->pid > ub->pid) return 1;
+
+  return 0;
+}
+
+/// @brief Perf does not emit MMAP2 records for already running processes.
+/// We will read through /proc/.../maps and get the virtual address mappings.
+void insert_initial_mappings() {
+  DIR *proc_dir;
+  struct dirent *pid_entry;
+
+  proc_dir = opendir("/proc");
+  ASSERT(proc_dir != NULL, "Unable to open /proc.");
+
+  while ((pid_entry = readdir(proc_dir))) {
+    if (!isdigit(pid_entry->d_name[0])) continue;
+
+    char maps_path[256];
+    int res = snprintf(maps_path, sizeof(maps_path), "/proc/%.230s/maps", pid_entry->d_name);
+    ASSERT(res > 0, "snprintf failed.");
+
+    FILE *maps = fopen(maps_path, "r");
+    if (maps == NULL) continue;
+
+    pid_t pid = (pid_t)atol(pid_entry->d_name);
+    ASSERT(pid != 0, "0 PID detected in /proc");
+    char line[4096];
+
+    while (fgets(line, sizeof(line), maps)) {
+      unsigned long start, end;
+      unsigned long offset;
+      char perms[5];
+      char path[4096] = "";
+
+      int res =
+          sscanf(line, "%lx-%lx %4s %lx %*x:%*x %*u %4095s", &start, &end, perms, &offset, path);
+
+      // Some /proc mappings are anonymous, and do not have a file. Instead of
+      // crashing, we ignore them by ensuring path[0] is not null.
+      ASSERT(res >= 4 && res <= 5, "Incorrectly read from /proc/.");
+
+      if (path[0]) {
+        size_t filename_len = strlen(path);
+        size_t total_size = sizeof(mmap2_record_t) + filename_len + 1;
+
+        // Allocate continuous memory for record + filename
+        mmap2_record_t *record = malloc(total_size);
+        memset(record, 0, total_size);
+
+        record->header.type = PERF_RECORD_MMAP2;
+        record->header.size = total_size;
+        record->pid = pid;
+        record->addr = start;
+        record->len = end - start;
+        record->pgoff = offset;
+
+        // Now copy filename to the space after the record
+        memcpy(record->filename, path, filename_len + 1);
+
+        finode_t finode;
+        get_file_info(record->filename, &finode);
+        record->ino = finode.ino;
+        record->maj = finode.maj;
+        record->min = finode.min;
+        record->ino_generation = finode.ino_generation;
+
+        insert_finode_entry(record);
+        insert_fname_entry(record);
+
+        free(record);
+      }
+    }
+    fclose(maps);
+  }
+}
+
+/// @brief Initializes FNAME_MAP data structures
+void init_fname_map() {
+  fname_map = btree_new(sizeof(filename_entry_t), 0, fname_compare, NULL);
+  btree_clear(fname_map);
+
+  insert_initial_mappings();
+}
+
+/// @brief Inserts a new MMAP2 record into FNAME_MAP.
+/// @param record Record to insert
+void insert_fname_entry(mmap2_record_t *record) {
+  if (!record) return;
+  ASSERT(record != NULL, "Input MMAP2 record is NULL.");
+  filename_entry_t key = {.pid = record->pid};
+
+  filename_entry_t *entry = (filename_entry_t *)btree_get(fname_map, &key);
+
+  // If the key does not exist (NULL), set up a new key, and allocate a new
+  // vector for the MMAP data
+  if (entry == NULL) {
+    entry = &key;
+    entry->virtual_address_map = vector_create();
+    btree_set(fname_map, entry);
+    ASSERT(!btree_oom(fname_map), "Fname-Map OOM.");
+  }
+
+  // After that, when it is guaranteed an entry exists, extract it
+  // and insert the new offset mapping into the vector
+
+  pid_virtual_map_entry_t *virtual_entry = malloc(sizeof(pid_virtual_map_entry_t));
+  virtual_entry->start = record->addr;
+  virtual_entry->end = record->addr + record->len;
+  virtual_entry->pgoff = record->pgoff;
+  virtual_entry->finode.ino = record->ino;
+  virtual_entry->finode.maj = record->maj;
+  virtual_entry->finode.min = record->min;
+  virtual_entry->finode.ino_generation = record->ino_generation;
+
+  // Add the value directly to the vector
+  vector_add(&entry->virtual_address_map, virtual_entry);
+}
+
+void free_filename_entry(filename_entry_t *entry_to_remove) {
+  pid_virtual_map_entry_t **vmap = entry_to_remove->virtual_address_map;
+  uint64_t vmap_size = vector_size(vmap);
+
+  for (uint64_t j = 0; j < vmap_size; j++) {
+    pid_virtual_map_entry_t *ventry = ((pid_virtual_map_entry_t **)vmap)[j];
+    free(ventry);
+  }
+
+  vector_free(entry_to_remove->virtual_address_map);
+  btree_delete(fname_map, entry_to_remove);
+}
+
+/// @brief Returns a cached entry or NULL if it doesn't exist.
+/// @param entry PID to find
+const filename_entry_t *get_filename_cached_entry(pid_t pid) {
+  // if (cached_entry && cached_entry->pid == pid) return cached_entry;
+  for (int i = 0; i < CACHE_DEPTH; i++) {
+    if (cached_entry[i] && cached_entry[i]->pid == pid) return cached_entry[i];
+  }
+  return NULL;
+}
+
+/// @brief Updates the cache with a new entry
+/// @param entry Entry to updated
+void update_filename_cached_entry(const filename_entry_t *entry) {
+  // Shift all entries down, discarding the oldest entry
+  for (int i = CACHE_DEPTH - 1; i > 0; i--) {
+    cached_entry[i] = cached_entry[i - 1];
+  }
+
+  // Put new entry at the front of the cache
+  cached_entry[0] = entry;
+}
+
+void prune_filename_cache(pid_t pid) {
+  for (int i = 0; i < CACHE_DEPTH; i++) {
+    if (cached_entry[i] && cached_entry[i]->pid == pid) {
+      cached_entry[i] = NULL;
+    }
+  }
+}
+
+/// @brief Removes all virtual offset mappings associated with a PID.
+/// @param pid PID to remove mappings for
+void remove_fname_entry(pid_t pid) {
+  filename_entry_t *entry =
+      (filename_entry_t *)btree_get(fname_map, &(filename_entry_t){.pid = pid});
+  if (entry != NULL) {
+    free_filename_entry(entry);
+    prune_filename_cache(pid);
+  }
+}
+
+/// @brief Converts an instruction pointer (program counter) into a filename and
+/// file offset, given
+///        the present active PID for the session.
+/// @param va VA to convert
+/// @param pid Active PID
+/// @param filename Passed in to populate filename
+/// @param offset Passed in to populate file offset
+/// @return -1 on failure to map, 0 on success
+bool va_to_file_offset(uint64_t va, pid_t pid, finode_t *finode, uint64_t *offset) {
+  if (!finode || !offset) return -1;
+  const filename_entry_t *entry = get_filename_cached_entry(pid);
+  if (entry == NULL) entry = btree_get(fname_map, &(filename_entry_t){.pid = pid});
+
+  if (entry == NULL || entry->pid != pid) return false;
+
+  update_filename_cached_entry(entry);
+
+  pid_virtual_map_entry_t **vmap = entry->virtual_address_map;
+  uint64_t vmap_size = vector_size(vmap);
+
+  for (size_t i = 0; i < vmap_size; i++) {
+    pid_virtual_map_entry_t *ventry = ((pid_virtual_map_entry_t **)vmap)[i];
+
+    if (va >= ventry->start && va < ventry->end) {
+      finode->ino = ventry->finode.ino;
+      finode->maj = ventry->finode.maj;
+      finode->min = ventry->finode.min;
+      finode->ino_generation = ventry->finode.ino_generation;
+
+      *offset = va - ventry->start + ventry->pgoff;
+
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/hotline/fname_map.h
+++ b/src/hotline/fname_map.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "btree.h"
+#include "finode_map.h"
+#include "perf_interface.h"
+
+#define CACHE_DEPTH 5
+
+/// @brief Virtual address start and end for each MMAP2 record. Will be stored
+/// within a B-Tree.
+typedef struct pid_virtual_map_entry {
+  uint64_t start;  // virtual address start
+  uint64_t end;    // virtual address end
+  uint64_t pgoff;  // file offset
+  // char *filename;
+  finode_t finode;
+} pid_virtual_map_entry_t;
+
+/// @brief For each filename and pid pair, we will store an array of all the
+/// mappings associated with it.
+typedef struct filename_entry {
+  pid_t pid;
+  pid_virtual_map_entry_t **virtual_address_map;  // array of pointers
+
+} filename_entry_t;
+
+/// @brief we can't just use a pointer to virtual_address_map because the B-Tree
+/// copies structs over, so our pointer may not point to the actual node in the
+/// tree. We copy over the relevant information, and cache it.
+typedef struct filename_entry_cache {
+  pid_t pid;
+  pid_virtual_map_entry_t **virtual_address_map;
+  finode_t finode;
+} filename_entry_cache_t;
+
+void init_fname_map();
+void insert_fname_entry(mmap2_record_t *record);
+void remove_fname_entry(pid_t pid);
+
+bool va_to_file_offset(uint64_t va, pid_t pid, finode_t *finode, uint64_t *offset);
+
+int fname_compare(const void *a, const void *b,
+                  void *udata);  // exposed for testing
+
+/// @brief Exposed B-Tree structure for all file mappings
+extern struct btree *fname_map;

--- a/src/hotline/hotline.c
+++ b/src/hotline/hotline.c
@@ -1,0 +1,559 @@
+#include "hotline.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "bmiss_map.h"
+#include "config.h"
+#include "finode_map.h"
+#include "fname_map.h"
+#include "lat_map.h"
+#include "log.h"
+#include "perf_interface.h"
+#include "sys.h"
+
+cpu_session_t *sessions = NULL;
+bool terminate_flag = 0;
+
+/// @brief syscall wrapper for invoking the perf event open syscall
+/// @param hw_event event attribute struct
+/// @param pid pid to profile, -1 if pid independent
+/// @param cpu cpu to profile, -1 if cpu independent
+/// @param group_fd fd to forward data to
+/// @param flags additional configuration flags
+/// @return result of the syscall
+int perf_event_open(struct perf_event_attr *hw_event, pid_t pid, int cpu, int group_fd,
+                    unsigned long flags) {
+  int ret;
+  ret = syscall(SYS_perf_event_open, hw_event, pid, cpu, group_fd, flags);
+  return ret;
+}
+
+/// @brief Initializes the hardware perf event for the PMU
+/// @param session Active CPU session
+void init_perf_hardware_event(cpu_session_t *session) {
+  int fd;
+  struct perf_event_attr attr;
+  memset(&attr, 0, sizeof(attr));
+  attr.type = cpu_system_config.perf_event_type;
+  attr.config = PERF_ARM_SPE_RAW_CONFIG;
+  attr.size = sizeof(attr);
+  attr.disabled = 1;
+  attr.inherit = 1;
+  attr.read_format = PERF_FORMAT_ID | PERF_FORMAT_SPE;
+  attr.sample_type = PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU |
+                     PERF_SAMPLE_DATA_SRC | PERF_SAMPLE_IDENTIFIER | PERF_SAMPLE_BRANCH_STACK;
+  attr.sample_period = cpu_system_config.frequency / profile_configuration.hotline_frequency;
+  attr.sample_id_all = 1;
+  attr.context_switch = 1;
+  attr.aux_watermark = AUX_WATERMARK;
+  attr.exclude_guest = 1;
+  attr.branch_sample_type = PERF_SAMPLE_BRANCH_ANY;
+
+  // assign pid=-1 to profile for all processes, on this particular CPU
+  fd = perf_event_open(&attr, -1, session->cpu, -1, PERF_FLAG_FD_CLOEXEC);
+  ASSERT(fd != -1, "Failed to open perf hardware event.");
+
+  session->hardware_fd = fd;
+}
+
+/// @brief Initializes the software perf event for the PMU, used for emitting
+/// context switches/MMAP2/exits
+/// @param session Active CPU session
+void init_perf_software_event(cpu_session_t *session) {
+  struct perf_event_attr attr;
+  int fd;
+  memset(&attr, 0, sizeof(attr));
+  attr.type = PERF_TYPE_SOFTWARE;
+  attr.size = sizeof(attr);
+  attr.config = PERF_COUNT_SW_DUMMY;
+  attr.sample_period = cpu_system_config.frequency / profile_configuration.hotline_frequency;
+  attr.sample_type = PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU |
+                     PERF_SAMPLE_IDENTIFIER;
+  attr.read_format = PERF_FORMAT_ID | PERF_FORMAT_SPE;
+  attr.disabled = 1;
+  // attr.inherit = 1;
+  attr.exclude_kernel = 1;
+  attr.exclude_hv = 1;
+  attr.mmap = 1;
+  // attr.comm = 1;
+  // attr.task = 1;
+  attr.sample_id_all = 1;
+  attr.exclude_guest = 1;
+  attr.mmap2 = 1;
+  // attr.comm_exec = 1;
+  attr.context_switch = 1;
+  // attr.ksymbol = 1;
+  // attr.bpf_event = 1;
+  attr.watermark = 1;
+
+  fd = perf_event_open(&attr, -1, session->cpu, -1, PERF_FLAG_FD_CLOEXEC);
+  ASSERT(fd != -1, "Failed to open perf software event.");
+
+  session->software_fd = fd;
+}
+
+/// @brief MMAPs record and aux buffers for the perf events
+/// @param session Active CPU session
+void mmap_perf_buffers(cpu_session_t *session) {
+  perf_buffer_size_t buffer_sizes;
+  get_perf_buffer_sizes(&buffer_sizes);
+
+  struct perf_event_mmap_page *meta_page = (struct perf_event_mmap_page *)mmap(
+      NULL, buffer_sizes.perf_record_buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED,
+      session->hardware_fd, 0);
+
+  ASSERT(meta_page != MAP_FAILED, "Failed to mmap perf buffer.");
+
+  meta_page->aux_offset = buffer_sizes.perf_aux_off;
+  meta_page->aux_size = buffer_sizes.perf_aux_buf_sz;
+
+  void *aux_buffer = mmap(NULL, buffer_sizes.perf_aux_buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED,
+                          session->hardware_fd, buffer_sizes.perf_aux_off);
+
+  ASSERT(aux_buffer != MAP_FAILED, "Failed to mmap aux buffer.");
+
+  session->meta_page = meta_page;
+  session->perf_software_buffer = (char *)meta_page + cpu_system_config.page_size;
+  session->perf_aux_buffer = aux_buffer;
+}
+
+/// @brief initializes the hardware and software perf events for a CPU session
+void init_perf_events(cpu_session_t *session) {
+  init_perf_hardware_event(session);
+  init_perf_software_event(session);
+  mmap_perf_buffers(session);
+
+  int ret = fcntl(session->hardware_fd, F_SETFL, O_RDONLY | O_NONBLOCK);
+  ASSERT(ret != -1, "Failed to set hardware event to non-blocking.");
+  ret = ioctl(session->software_fd, PERF_EVENT_IOC_SET_OUTPUT, session->hardware_fd);
+  ASSERT(ret != -1, "Failed to set software event output to hardware event.");
+  ret = fcntl(session->software_fd, F_SETFL, O_RDONLY | O_NONBLOCK);
+  ASSERT(ret != -1, "Failed to set software event to non-blocking.");
+}
+
+/// @brief Toggles the PMU to either enable, disable, or reset
+/// @param session Active CPU session
+/// @param toggle Flag to toggle to
+void toggle_pmu(cpu_session_t *session, uint64_t toggle) {
+  int ret;
+  ret = ioctl(session->hardware_fd, toggle, 0);
+  ret = ioctl(session->software_fd, toggle, 0);
+  // we don't need to toggle the software_fd after this. This is because
+  // hardware_fd is the leader of the group, and both are going to be scheduled
+  // together, so if hardware_fd is disabled, software_fd is essentially
+  // disabled (cannot be scheduled).
+  ASSERT(ret != -1, "Failed to toggle hardware PMU");
+}
+
+/// @brief Configures the time conversions for the perf event so we can convert
+/// from SPE to perf
+/// @param session Active CPU session
+void configure_session_conv(cpu_session_t *session) {
+  session->conv.cap_user_time_short = 1;
+  session->conv.cap_user_time_zero = 1;
+  session->conv.time_cycles = session->meta_page->time_cycles;
+  session->conv.time_mask = session->meta_page->time_mask;
+  session->conv.time_mult = session->meta_page->time_mult;
+  session->conv.time_shift = session->meta_page->time_shift;
+  session->conv.time_zero = session->meta_page->time_zero;
+}
+
+/// @brief Initializes all the perf events for each CPU
+void init_sessions() {
+  sessions = malloc(sizeof(cpu_session_t) * cpu_system_config.num_cpus);
+  memset(sessions, 0, sizeof(cpu_session_t) * cpu_system_config.num_cpus);
+  ASSERT(sessions != NULL, "Failed to malloc sessions.");
+  for (uint64_t i = 0; i < cpu_system_config.num_cpus; i++) {
+    sessions[i].cpu = i;
+    init_perf_events(&sessions[i]);
+    configure_session_conv(&sessions[i]);
+  }
+}
+
+/// @brief Enables perf profiling across all CPUs
+void enable_perf_profiling() {
+  for (uint64_t i = 0; i < cpu_system_config.num_cpus; i++) {
+    toggle_pmu(&sessions[i], PERF_EVENT_IOC_ENABLE);
+  }
+}
+
+/// @brief Conversion function from SPE time scale to Perf time scale, so we can
+/// directly compare the two records.
+/// referenced from linux perf: linux/tools/perf/util/tsc.c and
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+/// @param cyc cycles in SPE time scale
+/// @param session CPU session, which has meta_page and conversion info
+/// @return perf time
+// uint64_t tsc_to_perf_time(uint64_t cyc, struct perf_tsc_conversion *tc) {
+uint64_t tsc_to_perf_time(uint64_t cyc, cpu_session_t *session) {
+  uint64_t quot, rem;
+
+  volatile struct perf_event_mmap_page *meta = session->meta_page;
+
+  if (meta->cap_user_time_short)
+    cyc = meta->time_cycles + ((cyc - meta->time_cycles) & meta->time_mask);
+
+  quot = cyc >> meta->time_shift;
+  rem = cyc & (((uint64_t)1 << meta->time_shift) - 1);
+  return meta->time_zero + quot * meta->time_mult + ((rem * meta->time_mult) >> meta->time_shift);
+}
+
+/// @brief Given a perf record, gets the timestamp from it. Special care is
+///       required for MMAP2 records. Returns `0` on no event found, and the
+///       timestamp of the record.
+uint64_t get_perf_event_timestamp(struct perf_event_header *header) {
+  switch (header->type) {
+    case PERF_RECORD_AUX: {
+      return ((aux_record_t *)header)->sid.time;
+    }
+
+    // We need to handle the PERF_RECORD_MMAP2 separately because of the `char
+    // filename[];`. The sample sid struct is *after* the filename, so we use
+    // full size of the record, offset it by the sample id, and extract the
+    // timestamp.
+    case PERF_RECORD_MMAP2: {
+      mmap2_record_t *mmap2_rec = (mmap2_record_t *)header;
+      size_t fixed_size = offsetof(mmap2_record_t, filename);
+      size_t filename_len = header->size - fixed_size - sizeof(struct sample_id);
+      sample_id_t *sid = (sample_id_t *)((char *)mmap2_rec + fixed_size + filename_len);
+      return sid->time;
+    }
+
+    case PERF_RECORD_SWITCH_CPU_WIDE: {
+      return ((switch_cpu_wide_record_t *)header)->sid.time;
+    }
+
+    case PERF_RECORD_EXIT: {
+      return ((process_exit_record_t *)header)->sid.time;
+    }
+
+    default: {
+      return 0;
+    }
+  }
+}
+
+/// @brief Processes a record for the perf record buffer
+/// @param session Active CPU session
+/// @param header Perf header for the record to process
+static inline void process_software_buffer_record(struct perf_event_header *header,
+                                                  cpu_session_t *session) {
+  switch (header->type) {
+    case PERF_RECORD_MMAP2: {
+      struct mmap2_record *mmap2_rec = (struct mmap2_record *)header;
+
+      // logic to update fname_map
+      insert_finode_entry(mmap2_rec);  // add mapping to inodes for decoding later
+      insert_fname_entry(mmap2_rec);
+      break;
+    }
+
+    case PERF_RECORD_EXIT: {
+      struct process_exit_record *exit = (struct process_exit_record *)header;
+
+      // logic to remove pid from fname_map
+      remove_fname_entry(exit->pid);
+      break;
+    }
+
+    case PERF_RECORD_SWITCH_CPU_WIDE: {
+      struct switch_cpu_wide_record *switch_rec = (struct switch_cpu_wide_record *)header;
+      session->active_pid = switch_rec->header.misc & PERF_RECORD_MISC_SWITCH_OUT
+                                ? (pid_t)switch_rec->next_prev_pid
+                                : session->active_pid;
+      break;
+    }
+
+    case PERF_RECORD_MMAP:
+    case PERF_RECORD_SAMPLE:
+    case PERF_RECORD_AUX:
+    case PERF_RECORD_ITRACE_START:
+    case PERF_RECORD_LOST_SAMPLES:
+    case PERF_RECORD_LOST:
+    case PERF_RECORD_THROTTLE:
+    case PERF_RECORD_UNTHROTTLE:
+    case PERF_RECORD_READ:
+    case PERF_RECORD_COMM:
+    case PERF_RECORD_FORK:
+    case PERF_RECORD_SWITCH: {
+      break;
+    }
+
+    case PERF_RECORD_NAMESPACES:
+    case PERF_RECORD_KSYMBOL:
+    case PERF_RECORD_BPF_EVENT:
+    case PERF_RECORD_CGROUP:
+    case PERF_RECORD_TEXT_POKE: {
+      ASSERT(false, "Unexpected buffer entry.");
+    }
+  }
+}
+
+/// @brief Process a record for the AUX buffer
+/// @param session Active CPU session
+/// @param record Record to process
+void process_aux_buffer_record(cpu_session_t *session, spe_record_raw_t *record) {
+  uint64_t pc;
+  memcpy(&pc, &record->pc, 7);
+  pc = pc & 0x00FFFFFFFFFFFFFF;  // zero out the top byte because
+                                 // SPE PC is 7 bytes
+
+  uint64_t offset;
+  finode_t finode;
+  bool res = va_to_file_offset(pc, session->active_pid, &finode, &offset);
+
+  if (res == false) {
+    return;  // unable to map pc back to file/file offset
+  }
+
+  switch (record->type) {
+    case AUX_PACKET_TYPE_LAT:
+      parse_and_insert_lat_entry(record, &finode, offset);
+      break;
+
+    case AUX_PACKET_TYPE_BRANCH:
+      parse_and_insert_bmiss_entry(record, &finode, offset);
+      break;
+  }
+}
+
+/// @brief Process all the entries in the record buffer up to the `target_ts`
+/// @param session Active CPU session
+/// @param target_ts Timestamp to go up until
+void process_software_buffer_up_to_ts(cpu_session_t *session, uint64_t target_ts) {
+  char *data_page = session->perf_software_buffer;
+  uint64_t data_head = session->meta_page->data_head;
+  uint64_t data_tail = session->last_record_tail;  // use session's last position
+  // "On SMP-capable platforms, after reading the data_head value, user space
+  // should issue an rmb()."
+  // https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+#ifdef __aarch64__
+  asm volatile("dmb ishld" ::: "memory");  // memory barrier for reading
+#endif
+  uint64_t data_size = session->meta_page->data_size;
+
+  // use the last recorded timestamp to continue from
+  uint64_t last_ts = session->last_record_ts;
+
+  while (data_tail + sizeof(struct perf_event_header) < data_head) {
+    struct perf_event_header *header =
+        (struct perf_event_header *)(data_page + (data_tail % data_size));
+
+    if (data_tail + header->size > data_head) {
+      break;
+    }
+
+    uint64_t record_ts = get_perf_event_timestamp(header);
+
+    if (record_ts > target_ts) {
+      break;  // don't process this record. Note, `record_ts = 0` records (i.e.
+              // those that don't have a timestamp), are skippped.
+    }
+
+    last_ts = record_ts;  // update the last processed timestamp
+
+    process_software_buffer_record(header, session);
+
+    data_tail += header->size;
+  }
+
+  session->last_record_ts = last_ts;
+  session->last_record_tail = data_tail;
+
+  session->meta_page->data_tail = data_tail;
+}
+
+/// @brief Processes all the aux buffer entries for a CPU session
+/// @param session Active CPU session
+void process_aux_buffer(cpu_session_t *session) {
+  void *aux = session->perf_aux_buffer;
+  uint64_t aux_size = session->meta_page->aux_size;
+  uint64_t aux_head = session->meta_page->aux_head;
+
+  // "On SMP-capable platforms, after reading the data_head value, user space
+  // should issue an rmb()." The same must be done for the `aux_head`, according
+  // to the docs. https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+#ifdef __aarch64__
+  asm volatile("dmb ishld" ::: "memory");  // memory barrier for reading
+#endif
+  uint64_t aux_tail = session->last_aux_tail;
+
+  uint64_t last_processed_ts = 0;
+
+  // we use 2 * sizeof(spe_record_raw_t) to avoid a possible edge case where SPE
+  // writes a sample before a SWITCH record is emitted
+  while (aux_tail + 2 * sizeof(spe_record_raw_t) <= aux_head) {
+    spe_record_raw_t *record = (spe_record_raw_t *)(aux + (aux_tail % aux_size));
+
+    uint64_t timestamp = record->timestamp;
+
+    uint64_t perf_ts = tsc_to_perf_time(timestamp, session);
+
+    if (perf_ts >= last_processed_ts) {
+      process_software_buffer_up_to_ts(session, perf_ts);
+      // at this point, we should have the current active PID, and all the
+      // mappings should be updated
+
+      process_aux_buffer_record(session, record);
+      last_processed_ts = perf_ts;
+    }
+
+    aux_tail += sizeof(spe_record_raw_t);
+    session->last_aux_tail = aux_tail;
+    session->meta_page->aux_tail = aux_tail;
+  }
+}
+
+void serialize_bmiss_map() {
+  char path[4096];
+  FILE *branch_fp = NULL;
+  struct btree_iter *iter = NULL;
+  bool ok;
+
+  // open branch file
+  int res = snprintf(path, sizeof(path), "%s/%s", profile_configuration.data_dir,
+                     profile_configuration.bmiss_map_filename);
+  ASSERT(res >= 0, "Failed to create branch path.");
+  branch_fp = fopen(path, "w");
+
+  // write header
+  res = fprintf(branch_fp,
+                "filename,offset,count,not_taken_branches,"
+                "mispredicted,total_latency,issue_latency,branch_type\n");
+  ASSERT(res >= 0, "Failed to write branch header.");
+
+  // write branch map entries
+  iter = btree_iter_new(bmiss_map);
+  ok = btree_iter_seek(iter, &(bmiss_map_entry_t){});
+
+  while (ok) {
+    const bmiss_map_entry_t *entry = btree_iter_item(iter);
+    finode_map_entry_t key = {0};
+    key.finode = entry->finode;
+    const finode_map_entry_t *finode_entry = btree_get(finode_map, &key);
+
+    ASSERT(finode_entry != NULL, "Failed to recover filename.");
+
+    int write_result =
+        fprintf(branch_fp, "%s,0x%lx,%lu,%lu,%x\n", finode_entry->filename, entry->offset,
+                entry->count, entry->mispredicted, entry->branch_type);
+    ASSERT(write_result >= 0, "Failed to write branch entry");
+    ok = btree_iter_next(iter);
+  }
+
+  fclose(branch_fp);
+}
+
+void serialize_lat_map() {
+  char path[4096];
+  FILE *lat_fp = NULL;
+  struct btree_iter *iter = NULL;
+  bool ok;
+
+  // open lat file
+  int res = snprintf(path, sizeof(path), "%s/%s", profile_configuration.data_dir,
+                     profile_configuration.lat_map_filename);
+  ASSERT(res >= 0, "Failed to create load path.");
+  lat_fp = fopen(path, "w");
+
+  ASSERT(lat_fp != NULL, "Failed to open output files");
+
+  // write header
+  res = fprintf(lat_fp,
+                "filename,offset,count,total_latency,issue_latency,"
+                "translation_latency,"
+                "l1_bin1,l1_bin2,l1_bin3,l1_bin4,"
+                "l2_bin1,l2_bin2,l2_bin3,l2_bin4,"
+                "l3_bin1,l3_bin2,l3_bin3,l3_bin4,"
+                "dram_bin1,dram_bin2,dram_bin3,dram_bin4,saturated\n");
+  ASSERT(res >= 0, "Failed to write lat map header.");
+
+  // write lat map entries
+  iter = btree_iter_new(lat_map);
+  ok = btree_iter_seek(iter, &(lat_map_entry_t){});
+
+  while (ok) {
+    const lat_map_entry_t *entry = btree_iter_item(iter);
+    finode_map_entry_t key = {0};
+    key.finode = entry->finode;
+    const finode_map_entry_t *finode_entry = btree_get(finode_map, &key);
+
+    ASSERT(finode_entry != NULL, "Failed to recover filename.");
+
+    int write_result =
+        fprintf(lat_fp,
+                "%s,0x%lx,%lu,%lu,%lu,%lu,"
+                "%lu,%lu,%lu,%lu,"        // l1 bins
+                "%lu,%lu,%lu,%lu,"        // l2 bins
+                "%lu,%lu,%lu,%lu,"        // l3 bins
+                "%lu,%lu,%lu,%lu,%lu\n",  // dram bins
+                finode_entry->filename, entry->offset, entry->count, entry->total_latency,
+                entry->issue_latency, entry->translation_latency, entry->l1.l1_bound_bin,
+                entry->l1.l2_bound_bin, entry->l1.l3_bound_bin, entry->l1.dram_bound_bin,
+                entry->l2.l1_bound_bin, entry->l2.l2_bound_bin, entry->l2.l3_bound_bin,
+                entry->l2.dram_bound_bin, entry->l3.l1_bound_bin, entry->l3.l2_bound_bin,
+                entry->l3.l3_bound_bin, entry->l3.dram_bound_bin, entry->dram.l1_bound_bin,
+                entry->dram.l2_bound_bin, entry->dram.l3_bound_bin, entry->dram.dram_bound_bin,
+                entry->saturated);
+    ok = btree_iter_next(iter);
+    ASSERT(write_result >= 0, "Failed to write lat entry");
+  }
+
+  fclose(lat_fp);
+}
+
+/// @brief Serializes the lat_map and bmiss_map into files
+void serialize_maps() {
+  serialize_bmiss_map();
+  serialize_lat_map();
+}
+
+void handle_signal(int signum __attribute__((unused))) { terminate_flag = true; }
+
+uint64_t clock_gettime_monotonic() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+/// @brief Exposed wrapper function that APerf will call
+/// @param argc Standard C like argc
+/// @param argv Standard C like argv
+void hotline(int argc, char *argv[]) {
+  init_sys_info();
+  parse_arguments(argc, argv);
+
+  init_sessions();
+  init_finode_map();
+  init_fname_map();
+  init_lat_map();
+  init_bmiss_map();
+
+  // configure signal handling
+  struct sigaction sa = {.sa_handler = handle_signal, .sa_flags = 0};
+  sigemptyset(&sa.sa_mask);
+
+  ASSERT(sigaction(SIGTERM, &sa, NULL) != -1, "Sigaction failed.");
+
+  uint64_t start_time = clock_gettime_monotonic();
+  uint64_t timeout_ns = (uint64_t)profile_configuration.timeout * 1000000000ULL;
+
+  uint64_t end_time = start_time + timeout_ns;
+
+  enable_perf_profiling();
+
+  while (clock_gettime_monotonic() < end_time && !terminate_flag) {
+    sleep(profile_configuration.wakeup_period);
+    for (uint64_t c = 0; c < cpu_system_config.num_cpus; c++) {
+      process_aux_buffer(&sessions[c]);
+    }
+  }
+
+  serialize_maps();
+}

--- a/src/hotline/hotline.h
+++ b/src/hotline/hotline.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+
+// Referenced from ARM Neoverse V2 Core TRM, Section 22
+// and ARM SPE Performance Analysis Methodology White Paper, Section 2
+#define PERF_ARM_SPE_RAW_CONFIG 0x10001  // enable load collection, branch collection
+#define PERF_FORMAT_SPE 0x10
+
+#define AUX_WATERMARK 64  // watermark notification for PERF_SAMPLE_AUX record generation
+
+/// @brief populated from the first page of the buffers. Provides information on
+/// how to convert between SPE time scale and perf time scale.
+struct perf_tsc_conversion {
+  uint16_t time_shift;
+  uint32_t time_mult;
+  uint64_t time_zero;
+  uint64_t time_cycles;
+  uint64_t time_mask;
+
+  int cap_user_time_zero;
+  int cap_user_time_short;
+};
+
+/// @brief CPU specific information
+typedef struct cpu_session {
+  uint32_t cpu;
+  struct perf_tsc_conversion conv;  // ideally same across CPUs, but each core
+                                    // emits it's own configuration
+  uint64_t hardware_fd, software_fd;
+  volatile struct perf_event_mmap_page *meta_page;
+  void *perf_software_buffer;
+  void *perf_aux_buffer;
+
+  pid_t active_pid;
+  uint64_t last_ctx_tail;
+
+  // used for traversing buffers and updating B-Trees
+  uint64_t last_aux_tail, last_record_tail;
+  uint64_t last_aux_ts, last_record_ts;
+} cpu_session_t;
+
+void hotline(int argc, char *argv[]);

--- a/src/hotline/lat_map.c
+++ b/src/hotline/lat_map.c
@@ -1,0 +1,171 @@
+#include "lat_map.h"
+
+#include <string.h>
+
+#include "log.h"
+#include "perf_interface.h"
+#include "sys.h"
+
+struct btree *lat_map = NULL;
+
+/// @brief B-Tree comparison function for `lat_map_entry_t`
+/// @param a First entry to compare
+/// @param b Second entry to compare
+/// @param udata Unused
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int lat_map_compare(const void *a, const void *b, void *udata) {
+  (void)udata;
+  const lat_map_entry_t *ua = a;
+  const lat_map_entry_t *ub = b;
+
+  // Compare ino first as it's likely to be unique most often
+  if (ua->finode.ino > ub->finode.ino)
+    return 1;
+  else if (ua->finode.ino < ub->finode.ino)
+    return -1;
+
+  // then check offset as it should never be the same between two lat_map_entry_ts with the same
+  // file
+  if (ua->offset > ub->offset)
+    return 1;
+  else if (ua->offset < ub->offset)
+    return -1;
+
+  // then check the device associated info
+  if (ua->finode.maj > ub->finode.maj)
+    return 1;
+  else if (ua->finode.maj < ub->finode.maj)
+    return -1;
+
+  if (ua->finode.min > ub->finode.min)
+    return 1;
+  else if (ua->finode.min < ub->finode.min)
+    return -1;
+
+  // this should rarely change so check if last
+  if (ua->finode.ino_generation > ub->finode.ino_generation)
+    return 1;
+  else if (ua->finode.ino_generation < ub->finode.ino_generation)
+    return -1;
+
+  return 0;
+}
+
+/// @brief Initializes the lat_map
+void init_lat_map() {
+  lat_map = btree_new(sizeof(lat_map_entry_t), 0, lat_map_compare, NULL);
+  btree_clear(lat_map);
+}
+
+static inline void update_histogram(completion_histogram_t *dst, const completion_histogram_t *src1,
+                                    const completion_histogram_t *src2) {
+  dst->l1_bound_bin = src1->l1_bound_bin + src2->l1_bound_bin;
+  dst->l2_bound_bin = src1->l2_bound_bin + src2->l2_bound_bin;
+  dst->l3_bound_bin = src1->l3_bound_bin + src2->l3_bound_bin;
+  dst->dram_bound_bin = src1->dram_bound_bin + src2->dram_bound_bin;
+}
+
+/// @brief Inserts a `lat_map_entry_t` into the lat_map
+/// @param entry_to_insert Entry to insert
+inline void insert_lat_map_entry(lat_map_entry_t *entry_to_insert) {
+  if (!entry_to_insert) return;
+  lat_map_entry_t tmp_entry = {0};
+
+  lat_map_entry_t *entry = (lat_map_entry_t *)btree_get(lat_map, entry_to_insert);
+
+  if (entry == NULL) {
+    entry = &tmp_entry;
+    entry->finode = entry_to_insert->finode;
+    entry->offset = entry_to_insert->offset;
+  }
+
+  lat_map_entry_t updated_entry = {0};  // copy over existing + new stats into a
+                                        // new entry, then call btree_set
+                                        // we need to btree_get again because
+                                        // the btree data structure copies over
+                                        // and malloc's it's own internal struct
+  updated_entry.finode = entry->finode;
+  updated_entry.offset = entry->offset;
+
+  updated_entry.total_latency = entry->total_latency + entry_to_insert->total_latency;
+  updated_entry.issue_latency = entry->issue_latency + entry_to_insert->issue_latency;
+  updated_entry.translation_latency =
+      entry->translation_latency + entry_to_insert->translation_latency;
+  updated_entry.saturated = entry->saturated + entry_to_insert->saturated;
+  updated_entry.count = entry->count + entry_to_insert->count;
+
+  for (int i = 0; i < 4; i++) {
+    update_histogram(&updated_entry.histograms[i], &entry->histograms[i],
+                     &entry_to_insert->histograms[i]);
+  }
+
+  btree_set(lat_map, &updated_entry);
+  ASSERT(!btree_oom(lat_map), "Lat Map OOM.");
+}
+
+/// @brief Parses a raw SPE entry into a struct that lat_map can use
+/// @param record Raw record to parse
+/// @param entry lat_map struct to parse into
+/// @param filename Filename to associate, decoded from `pc_to_file_offset`
+/// @param offset File offset to associate, decoded from `pc_to_file_offset`
+inline void parse_lat_map_entry(spe_record_raw_t *record, lat_map_entry_t *entry, finode_t *finode,
+                                uint64_t offset) {
+  if (!record || !entry || !finode) return;
+  entry->saturated = (record->issue_lat == AUX_PACKET_SATURATED) ? 1 : 0;
+  entry->count = 1;
+  entry->finode.ino = finode->ino;
+  entry->finode.maj = finode->maj;
+  entry->finode.min = finode->min;
+  entry->finode.ino_generation = finode->ino_generation;
+  entry->offset = offset;
+
+  // don't update statistics if saturated
+  if (entry->saturated) return;
+
+  entry->total_latency = record->total_lat * cpu_system_config.cyc_to_ps_conv_factor;
+  entry->issue_latency = record->issue_lat * cpu_system_config.cyc_to_ps_conv_factor;
+  entry->translation_latency = record->x_lat * cpu_system_config.cyc_to_ps_conv_factor;
+
+  // determine which bin we need to update based on data source
+  completion_histogram_t *bin;
+  switch (record->data_source) {
+    case DATA_SOURCE_L1:
+      bin = &entry->l1;
+      break;
+    case DATA_SOURCE_L2:
+      bin = &entry->l2;
+      break;
+    case DATA_SOURCE_LOCAL_CLUSTER:
+    case DATA_SOURCE_PEER_CLUSTER:
+    case DATA_SOURCE_SYSTEM_CACHE:
+      bin = &entry->l3;
+      break;
+    default:
+      bin = &entry->dram;
+  }
+
+  uint64_t execution_latency =
+      entry->total_latency - entry->issue_latency - entry->translation_latency;
+
+  if (execution_latency <= cpu_system_config.latency_limits.l1_latency_cap_ps)
+    bin->l1_bound_bin = 1;
+  else if (execution_latency <= cpu_system_config.latency_limits.l2_latency_cap_ps)
+    bin->l2_bound_bin = 1;
+  else if (execution_latency <= cpu_system_config.latency_limits.l3_latency_cap_ps)
+    bin->l3_bound_bin = 1;
+  else
+    bin->dram_bound_bin = 1;
+}
+
+/// @brief Combines parse and insert with inline because these are called very
+/// frequently.
+/// @param record Record to parse and insert
+/// @param finode Finode of file associated with a virtual address
+/// @param offset Offset into the file
+void parse_and_insert_lat_entry(spe_record_raw_t *record, finode_t *finode, uint64_t offset) {
+  lat_map_entry_t lat_entry = {0};
+  // parse_lat_map_entry and insert_lat_map are inlined for potential
+  // compiler optimizations
+  parse_lat_map_entry(record, &lat_entry, finode, offset);
+  insert_lat_map_entry(&lat_entry);
+}

--- a/src/hotline/lat_map.h
+++ b/src/hotline/lat_map.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "btree.h"
+#include "finode_map.h"
+
+/// @brief Struct to package latency binning information for completion node
+/// data report
+typedef struct completion_histogram {
+  uint64_t l1_bound_bin;
+  uint64_t l2_bound_bin;
+  uint64_t l3_bound_bin;
+  uint64_t dram_bound_bin;
+} completion_histogram_t;
+
+/// @brief B-Tree structure for SPE latency information of load/store
+/// instructions
+typedef struct lat_map_entry {
+  union {  // union allows data storing and report generation to use the same
+           // parameters rather than having to redefine them each time.
+    finode_t finode;
+    char *filename;
+  };
+  uint64_t offset;
+  uint64_t total_latency;
+  uint64_t issue_latency;
+  uint64_t translation_latency;
+  uint64_t saturated;
+  uint64_t count;
+  union {
+    struct {
+      completion_histogram_t l1, l2, l3, dram;
+    };
+    completion_histogram_t histograms[4];  // array access option
+  };
+} lat_map_entry_t;
+
+void init_lat_map();
+void insert_lat_map_entry(lat_map_entry_t *entry);
+void parse_lat_map_entry(spe_record_raw_t *record, lat_map_entry_t *entry, finode_t *finode,
+                         uint64_t offset);
+void parse_and_insert_lat_entry(spe_record_raw_t *record, finode_t *finode, uint64_t offset);
+
+extern struct btree *lat_map;

--- a/src/hotline/log.h
+++ b/src/hotline/log.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Preprocessor macro that is used for error handling throughout
+// Exits on COND failure
+#define ASSERT(COND, MSG)                          \
+  do {                                             \
+    if (!(COND)) {                                 \
+      fputs("[hotline] ERROR: " MSG "\n", stderr); \
+      exit(EXIT_FAILURE);                          \
+    }                                              \
+  } while (0)

--- a/src/hotline/perf_interface.h
+++ b/src/hotline/perf_interface.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <linux/perf_event.h>
+#include <stdint.h>
+
+#define AUX_PACKET_TYPE_LAT 0x49
+#define AUX_PACKET_TYPE_BRANCH 0x4a
+#define AUX_RECORD_TYPE_BCOND 0x01
+#define AUX_PACKET_SATURATED 4095
+
+#define AUX_EVENT_RETIRED 1 << 1
+#define AUX_EVENT_BRANCH_NOT_TAKEN 1 << 6
+#define AUX_EVENT_BRANCH_MISS 1 << 7
+
+#define DATA_SOURCE_L1 0b0000
+#define DATA_SOURCE_L2 0b1000
+#define DATA_SOURCE_PEER_CORE 0b1001
+#define DATA_SOURCE_LOCAL_CLUSTER 0b1010
+#define DATA_SOURCE_SYSTEM_CACHE 0b1011
+#define DATA_SOURCE_PEER_CLUSTER 0b1100
+#define DATA_SOURCE_REMOTE 0b1101
+#define DATA_SOURCE_DRAM 0b1110
+
+/// @brief sample_id struct spec from
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+typedef struct sample_id {
+  uint32_t pid, tid;
+  uint64_t time;
+  uint32_t cpu, res;
+  uint64_t id;
+} sample_id_t;
+
+/// @brief aux record spec from
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+typedef struct __attribute__((packed)) aux_record {
+  struct perf_event_header header;
+  uint64_t aux_offset;
+  uint64_t aux_size;
+  uint64_t flags;
+  struct sample_id sid;
+} aux_record_t;
+
+/// @brief mmap2 record spec from
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+typedef struct __attribute__((packed)) mmap2_record {
+  struct perf_event_header header;
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t addr;
+  uint64_t len;
+  uint64_t pgoff;
+  union {
+    struct {
+      uint32_t maj;
+      uint32_t min;
+      uint64_t ino;
+      uint64_t ino_generation;
+    };
+
+    struct {
+      uint8_t bbuild_id_size;
+      uint8_t __reserved_1;
+      uint16_t __reserved_2;
+      uint8_t build_id[20];
+    };
+  };
+
+  uint32_t prot;
+  uint32_t flags;
+  char filename[];
+} mmap2_record_t;
+
+/// @brief switch_cpu_wide spec from
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+typedef struct __attribute__((packed)) switch_cpu_wide_record {
+  struct perf_event_header header;
+  uint32_t next_prev_pid;
+  uint32_t next_prev_tid;
+  struct sample_id sid;
+} switch_cpu_wide_record_t;
+
+/// @brief process_exit spec from
+/// https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+typedef struct __attribute__((packed)) process_exit_record {
+  struct perf_event_header header;
+  uint32_t pid, ppid;
+  uint32_t tid, ptid;
+  uint64_t time;
+  struct sample_id sid;
+} process_exit_record_t;
+
+/// @brief raw ARM SPE packet that the PMU emmits
+/// The contents of this struct are config dependent, which
+/// can be updated under hotline.c:init_perf_hardware_event
+typedef struct __attribute__((packed)) spe_record_raw {
+  uint8_t __reserved1;
+  uint8_t pc[7];
+  uint8_t __reserved2;
+  uint8_t __reserved3[10];
+  uint8_t type;
+  uint8_t reg;
+  uint8_t identifier;
+  uint32_t events_packet;
+  uint8_t __reserved4;
+  uint16_t issue_lat;
+  uint8_t __reserved5;
+  uint16_t total_lat;
+  uint64_t vaddr;
+  uint8_t __reserved6;
+  uint8_t __reserved7;
+  uint16_t x_lat;
+  uint8_t __reserved8[9];
+  uint8_t __reserved9;
+  uint8_t data_source;
+  uint8_t __reserved10;
+  uint64_t timestamp;
+} spe_record_raw_t;

--- a/src/hotline/report.c
+++ b/src/hotline/report.c
@@ -1,0 +1,520 @@
+#include "report.h"
+
+#include <string.h>
+
+#include "btree.h"
+#include "config.h"
+#include "fname_binary_map.h"
+#include "log.h"
+#include "sys.h"
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+/// @brief Reads the bmiss_map serialized file and stores it in memory
+/// @param filename Filename to read in
+/// @param out_count Count to populate for later iteration
+/// @return Pointer to malloc-ed file struct array
+bmiss_map_entry_t *deserialize_bmiss_map(const char *filename, uint64_t *out_count) {
+  FILE *fp = fopen(filename, "r");
+  ASSERT(fp != NULL, "Failed to open binary file.");
+
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t read;
+  size_t entry_count = 0;
+
+  size_t capacity = 64;
+  bmiss_map_entry_t *entries = malloc(capacity * sizeof(bmiss_map_entry_t));
+  ASSERT(entries != NULL, "Failed to allocate memory for entries.");
+
+  if ((read = getline(&line, &len, fp)) == -1) {
+    free(line);
+    free(entries);
+    fclose(fp);
+    return NULL;
+  }
+
+  while ((read = getline(&line, &len, fp)) != -1) {
+    if (entry_count >= capacity) {
+      capacity *= 2;
+      bmiss_map_entry_t *temp = realloc(entries, capacity * sizeof(bmiss_map_entry_t));
+      if (temp == NULL) {
+        free(entries);
+        free(line);
+        fclose(fp);
+        ASSERT(0, "Failed to reallocate memory for entries.");
+        return NULL;
+      }
+      entries = temp;
+    }
+
+    bmiss_map_entry_t *entry = &entries[entry_count];
+
+    // Temporary buffer for filename
+    char temp_filename[4096] = {0};
+
+    int result = sscanf(line, "%[^,],%lx,%lu,%lu,%hhx", temp_filename, &entry->offset,
+                        &entry->count, &entry->mispredicted, &entry->branch_type);
+
+    ASSERT(result == 5, "failed to sscanf bmiss line correctly.");
+
+    // Allocate memory for the filename and copy it
+    entry->filename = strdup(temp_filename);
+    if (entry->filename == NULL) {
+      // Handle memory allocation failure
+      fprintf(stderr, "Failed to allocate memory for filename\n");
+      continue;
+    }
+    entry_count++;
+  }
+
+  if (entry_count > 0) {
+    bmiss_map_entry_t *temp = realloc(entries, entry_count * sizeof(bmiss_map_entry_t));
+    if (temp != NULL) {
+      entries = temp;
+    }
+  }
+
+  *out_count = entry_count;
+  free(line);
+  fclose(fp);
+  return entries;
+}
+
+/// @brief Reads the lat_map serialized file and stores it in memory
+/// @param filename Filename to read in
+/// @param out_count Count to populate for later iteration
+/// @return Pointer to malloc-ed file struct array
+lat_map_entry_t *deserialize_lat_map(const char *filename, uint64_t *out_count) {
+  FILE *fp = fopen(filename, "r");
+  ASSERT(fp != NULL, "Failed to open binary file.");
+
+  char *line = NULL;
+  size_t len = 0;
+  ssize_t read;
+  size_t entry_count = 0;
+
+  size_t capacity = 64;
+  lat_map_entry_t *entries = malloc(capacity * sizeof(lat_map_entry_t));
+  ASSERT(entries != NULL, "Failed to allocate memory for entries.");
+
+  if ((read = getline(&line, &len, fp)) == -1) {
+    free(line);
+    free(entries);
+    fclose(fp);
+    return NULL;
+  }
+
+  while ((read = getline(&line, &len, fp)) != -1) {
+    if (entry_count >= capacity) {
+      capacity *= 2;
+      lat_map_entry_t *temp = realloc(entries, capacity * sizeof(lat_map_entry_t));
+      if (temp == NULL) {
+        free(entries);
+        free(line);
+        fclose(fp);
+        ASSERT(0, "Failed to reallocate memory for entries.");
+        return NULL;
+      }
+      entries = temp;
+    }
+
+    lat_map_entry_t *entry = &entries[entry_count];
+
+    // Temporary buffer for filename
+    char temp_filename[4096];
+
+    int result = sscanf(line,
+                        "%[^,],%lx,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,"
+                        "%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,"
+                        "%ld",
+                        temp_filename, &entry->offset, &entry->count, &entry->total_latency,
+                        &entry->issue_latency, &entry->translation_latency, &entry->l1.l1_bound_bin,
+                        &entry->l1.l2_bound_bin, &entry->l1.l3_bound_bin, &entry->l1.dram_bound_bin,
+                        &entry->l2.l1_bound_bin, &entry->l2.l2_bound_bin, &entry->l2.l3_bound_bin,
+                        &entry->l2.dram_bound_bin, &entry->l3.l1_bound_bin, &entry->l3.l2_bound_bin,
+                        &entry->l3.l3_bound_bin, &entry->l3.dram_bound_bin,
+                        &entry->dram.l1_bound_bin, &entry->dram.l2_bound_bin,
+                        &entry->dram.l3_bound_bin, &entry->dram.dram_bound_bin, &entry->saturated);
+
+    ASSERT(result == 23, "failed to sscanf lat line correctly.");
+    // Allocate memory for the filename and copy it
+    entry->filename = strdup(temp_filename);
+    ASSERT(entry->filename != NULL, "Failed to copy filename.");
+    entry_count++;
+  }
+
+  if (entry_count > 0) {
+    lat_map_entry_t *temp = realloc(entries, entry_count * sizeof(lat_map_entry_t));
+    if (temp != NULL) {
+      entries = temp;
+    }
+  }
+
+  *out_count = entry_count;
+  free(line);
+  fclose(fp);
+  return entries;
+}
+
+/// @brief Helper function to set up a file pointer for the reports
+/// @param file_dir Directory to create file
+/// @param filename Name of file
+/// @return File pointer to file
+FILE *setup_report_file(const char *file_dir, char *filename) {
+  size_t path_len = strlen(file_dir) + strlen(filename) + 2;
+  char *filepath = malloc(path_len);
+  ASSERT(filepath != NULL, "Failed to malloc file path.");
+  snprintf(filepath, path_len, "%s/%s", file_dir, filename);
+  FILE *fp = fopen(filepath, "w");
+  ASSERT(fp != NULL, "Failed to open file for writing.");
+
+  return fp;
+}
+
+/// @brief Used for sorting bmiss entries
+/// @param a First entry to compare
+/// @param b Second entry to compare
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int compare_bmiss_entries(const void *a, const void *b) {
+  const bmiss_map_entry_t *entry_a = (const bmiss_map_entry_t *)a;
+  const bmiss_map_entry_t *entry_b = (const bmiss_map_entry_t *)b;
+
+  // Sort by count (descending)
+  if (entry_b->count > entry_a->count) return 1;
+  if (entry_b->count < entry_a->count) return -1;
+  return 0;
+}
+
+/// @brief Generates the bmiss report after process_bmiss_entries is called
+/// @param file_dir File dir to generate report in
+/// @param entries bmiss_map_t entries to populate report with
+/// @param count Number of entries
+void generate_bmiss_report(const char *file_dir, bmiss_map_entry_t *entries, uint64_t count) {
+  FILE *fp = setup_report_file(file_dir, "hotline_bmiss_map.csv");
+
+  // write the header in
+  fprintf(fp,
+          "Sample Count,Mispredicted (%%),"
+          "Location:Line,Source Line,Function,Assembly,Type\n");
+
+  // Don't want to crash in case other reports have entries
+  if (entries == NULL || count == 0) {
+    fprintf(stderr, "No entries to process\n");
+    fclose(fp);
+    return;
+  }
+
+  qsort(entries, count, sizeof(bmiss_map_entry_t), compare_bmiss_entries);
+  for (size_t i = 0; i < MIN(count, profile_configuration.num_to_report); i++) {
+    const bmiss_map_entry_t *entry = &entries[i];
+
+    debug_info_t *dinfo = get_debug_info(entry->filename, entry->offset);
+
+    fprintf(
+        fp, "%ld,%.2f%%,%s:%ld,%s,%s,%s,%s\n", entries[i].count,
+        (entries[i].count > 0) ? ((double)entries[i].mispredicted / entries[i].count) * 100.0 : 0.0,
+        dinfo->src_file, dinfo->line_num, dinfo->line, dinfo->function, dinfo->assembly,
+        entries[i].branch_type == 0x01 ? "Conditional" : "Indirect");
+  }
+
+  fclose(fp);
+}
+
+/// @brief Comparison function for lat_map exec latencies
+/// @param a First entry to compare
+/// @param b Second entry to compre
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int compare_lat_exec_entries(const void *a, const void *b) {
+  const lat_map_entry_t *entry_a = (const lat_map_entry_t *)a;
+  const lat_map_entry_t *entry_b = (const lat_map_entry_t *)b;
+
+  // Calculate execution latencies
+  long exec_a = entry_a->total_latency - entry_a->issue_latency - entry_a->translation_latency;
+  long exec_b = entry_b->total_latency - entry_b->issue_latency - entry_b->translation_latency;
+
+  // Sort by execution latency (descending)
+  if (exec_b > exec_a) return 1;
+  if (exec_b < exec_a) return -1;
+  return 0;
+}
+
+/// @brief Writes a single exec latency entry to the file
+/// @param fp File pointer of file to write to
+/// @param entry Pointer to entry information
+/// @param dinfo Debug information struct
+void print_exec_latency(FILE *fp, const lat_map_entry_t *entry, const debug_info_t *dinfo) {
+  fprintf(fp, "%.2f,%ld,%ld,%s:%ld,%s,%s,%s\n",
+          (double)(entry->total_latency - entry->issue_latency - entry->translation_latency) /
+              (entry->count * 1000.0),
+          entry->count, entry->saturated, dinfo->src_file, dinfo->line_num, dinfo->line,
+          dinfo->function, dinfo->assembly);
+}
+
+/// @brief Comparison function for lat_map issue latencies
+/// @param a First entry to compare
+/// @param b Second entry to compre
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int compare_lat_issue_entries(const void *a, const void *b) {
+  const lat_map_entry_t *entry_a = (const lat_map_entry_t *)a;
+  const lat_map_entry_t *entry_b = (const lat_map_entry_t *)b;
+
+  // Sort by issue latency (descending)
+  if (entry_b->issue_latency > entry_a->issue_latency) return 1;
+  if (entry_b->issue_latency < entry_a->issue_latency) return -1;
+  return 0;
+}
+
+/// @brief Writes a single issue latency entry to the file
+/// @param fp File pointer of file to write to
+/// @param entry Pointer to entry information
+/// @param dinfo Debug information struct
+void print_issue_latency(FILE *fp, const lat_map_entry_t *entry, const debug_info_t *dinfo) {
+  fprintf(fp, "%.2f,%ld,%ld,%s:%ld,%s,%s,%s\n",
+          (double)(entry->issue_latency) / (entry->count * 1000.0), entry->count, entry->saturated,
+          dinfo->src_file, dinfo->line_num, dinfo->line, dinfo->function, dinfo->assembly);
+}
+
+/// @brief Comparison function for lat_map translation latencies
+/// @param a First entry to compare
+/// @param b Second entry to compre
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int compare_translation_issue_entries(const void *a, const void *b) {
+  const lat_map_entry_t *entry_a = (const lat_map_entry_t *)a;
+  const lat_map_entry_t *entry_b = (const lat_map_entry_t *)b;
+
+  // Sort by translation latency (descending)
+  if (entry_b->translation_latency > entry_a->translation_latency) return 1;
+  if (entry_b->translation_latency < entry_a->translation_latency) return -1;
+  return 0;
+}
+
+/// @brief Writes a single translation latency entry to the file
+/// @param fp File pointer of file to write to
+/// @param entry Pointer to entry information
+/// @param dinfo Debug information struct
+void print_translation_latency(FILE *fp, const lat_map_entry_t *entry, const debug_info_t *dinfo) {
+  fprintf(fp, "%.2f,%ld,%ld,%s:%ld,%s,%s,%s\n",
+          (double)(entry->translation_latency) / (entry->count * 1000.0), entry->count,
+          entry->saturated, dinfo->src_file, dinfo->line_num, dinfo->line, dinfo->function,
+          dinfo->assembly);
+}
+
+/// @brief Comparison function for lat_map completion node latencies
+/// @param a First entry to compare
+/// @param b Second entry to compre
+/// @return 1 if a > b, -1 if a < b, 0 if a = b
+int compare_completion_node_issue_entries(const void *a, const void *b) {
+  const lat_map_entry_t *entry_a = (const lat_map_entry_t *)a;
+  const lat_map_entry_t *entry_b = (const lat_map_entry_t *)b;
+
+  // Sort by total latency (descending)
+  if (entry_b->total_latency > entry_a->total_latency) return 1;
+  if (entry_b->total_latency < entry_a->total_latency) return -1;
+  return 0;
+}
+
+/// @brief Writes a single completion node entry to the file
+/// @param fp File pointer of file to write to
+/// @param entry Pointer to entry information
+/// @param dinfo Debug information struct
+void print_completion_node(FILE *fp, const lat_map_entry_t *entry, const debug_info_t *dinfo) {
+  // Calculate totals for each level
+  uint64_t l1_total = entry->l1.l1_bound_bin + entry->l1.l2_bound_bin + entry->l1.l3_bound_bin +
+                      entry->l1.dram_bound_bin;
+  uint64_t l2_total = entry->l2.l1_bound_bin + entry->l2.l2_bound_bin + entry->l2.l3_bound_bin +
+                      entry->l2.dram_bound_bin;
+  uint64_t l3_total = entry->l3.l1_bound_bin + entry->l3.l2_bound_bin + entry->l3.l3_bound_bin +
+                      entry->l3.dram_bound_bin;
+  uint64_t dram_total = entry->dram.l1_bound_bin + entry->dram.l2_bound_bin +
+                        entry->dram.l3_bound_bin + entry->dram.dram_bound_bin;
+
+  uint64_t grand_total = l1_total + l2_total + l3_total + dram_total;
+  if (grand_total == 0) grand_total = 1;
+
+  // Calculate level percentages
+  double l1_pct = (double)l1_total / grand_total * 100.0;
+  double l2_pct = (double)l2_total / grand_total * 100.0;
+  double l3_pct = (double)l3_total / grand_total * 100.0;
+  double dram_pct = (double)dram_total / grand_total * 100.0;
+
+  // Calculate bin percentages for L1
+  double l1_bins[4] = {l1_total > 0 ? (double)entry->l1.l1_bound_bin / l1_total * 100.0 : 0.0,
+                       l1_total > 0 ? (double)entry->l1.l2_bound_bin / l1_total * 100.0 : 0.0,
+                       l1_total > 0 ? (double)entry->l1.l3_bound_bin / l1_total * 100.0 : 0.0,
+                       l1_total > 0 ? (double)entry->l1.dram_bound_bin / l1_total * 100.0 : 0.0};
+
+  // Calculate bin percentages for L2
+  double l2_bins[4] = {l2_total > 0 ? (double)entry->l2.l1_bound_bin / l2_total * 100.0 : 0.0,
+                       l2_total > 0 ? (double)entry->l2.l2_bound_bin / l2_total * 100.0 : 0.0,
+                       l2_total > 0 ? (double)entry->l2.l3_bound_bin / l2_total * 100.0 : 0.0,
+                       l2_total > 0 ? (double)entry->l2.dram_bound_bin / l2_total * 100.0 : 0.0};
+
+  // Calculate bin percentages for L3
+  double l3_bins[4] = {l3_total > 0 ? (double)entry->l3.l1_bound_bin / l3_total * 100.0 : 0.0,
+                       l3_total > 0 ? (double)entry->l3.l2_bound_bin / l3_total * 100.0 : 0.0,
+                       l3_total > 0 ? (double)entry->l3.l3_bound_bin / l3_total * 100.0 : 0.0,
+                       l3_total > 0 ? (double)entry->l3.dram_bound_bin / l3_total * 100.0 : 0.0};
+
+  // Calculate bin percentages for DRAM
+  double dram_bins[4] = {
+      dram_total > 0 ? (double)entry->dram.l1_bound_bin / dram_total * 100.0 : 0.0,
+      dram_total > 0 ? (double)entry->dram.l2_bound_bin / dram_total * 100.0 : 0.0,
+      dram_total > 0 ? (double)entry->dram.l3_bound_bin / dram_total * 100.0 : 0.0,
+      dram_total > 0 ? (double)entry->dram.dram_bound_bin / dram_total * 100.0 : 0.0};
+
+  fprintf(fp,
+          "%.3f,%.3f | %.3f | %.3f | %.3f,"
+          "%.3f,%.3f | %.3f | %.3f | %.3f,"
+          "%.3f,%.3f | %.3f | %.3f | %.3f,"
+          "%.3f,%.3f | %.3f | %.3f | %.3f,"
+          "%s:%ld,%s,%s,%s\n",
+          l1_pct, l1_bins[0], l1_bins[1], l1_bins[2], l1_bins[3], l2_pct, l2_bins[0], l2_bins[1],
+          l2_bins[2], l2_bins[3], l3_pct, l3_bins[0], l3_bins[1], l3_bins[2], l3_bins[3], dram_pct,
+          dram_bins[0], dram_bins[1], dram_bins[2], dram_bins[3], dinfo->src_file, dinfo->line_num,
+          dinfo->line, dinfo->function, dinfo->assembly);
+}
+
+/// @brief Parametrized function to write a sub-report for lat_map
+/// @param entries Entries to write
+/// @param count Number of entries
+/// @param fp File pointer of file to write into
+/// @param compare_fn Comparison function for sorting entries
+/// @param print_fn Print function to write a single entry into `fp`
+void write_lat_map_sub_report(lat_map_entry_t *entries, uint64_t count, FILE *fp,
+                              int (*compare_fn)(const void *, const void *),
+                              void (*print_fn)(FILE *, const lat_map_entry_t *,
+                                               const debug_info_t *)) {
+  qsort(entries, count, sizeof(lat_map_entry_t), compare_fn);
+
+  for (size_t i = 0; i < MIN(count, profile_configuration.num_to_report); i++) {
+    const lat_map_entry_t *entry = &entries[i];
+    debug_info_t *dinfo = get_debug_info(entry->filename, entry->offset);
+    print_fn(fp, entry, dinfo);
+  }
+}
+
+/// @brief Calls write_lat_map_sub_report for each sub-view
+/// @param file_dir File directory to put reports into
+/// @param entries Entries to write
+/// @param count Number of entries
+void generate_lat_report(const char *file_dir, lat_map_entry_t *entries, uint64_t count) {
+  FILE *exec_fp = setup_report_file(file_dir, "hotline_lat_map_exec_report.csv");
+  FILE *issue_fp = setup_report_file(file_dir, "hotline_lat_map_issue_report.csv");
+  FILE *translation_fp = setup_report_file(file_dir, "hotline_lat_map_translation_report.csv");
+  FILE *completion_fp = setup_report_file(file_dir, "hotline_lat_map_completion_report.csv");
+
+  // write the headers in
+  fputs(
+      "Latency (ns),Sample Count,Dropped Packets,Location:Line,"
+      "Source Line,Function,Assembly\n",
+      exec_fp);
+
+  fputs(
+      "Latency (ns),Sample Count,Dropped Packets,Location:Line,"
+      "Source Line,Function,Assembly\n",
+      issue_fp);
+
+  fputs(
+      "Latency (ns),Sample Count,Dropped Packets,Location:Line,"
+      "Source Line,Function,Assembly\n",
+      translation_fp);
+
+  fprintf(completion_fp,
+          "L1 (%%),L1 latencies (%% <= %.1fns | %% <= %.1fns | %% <= %.1fns | %% > %.1fns),"
+          "L2 (%%),L2 latencies (%% <= %.1fns | %% <= %.1fns | %% <= %.1fns | %% > %.1fns),"
+          "L3 (%%),L3 latencies (%% <= %.1fns | %% <= %.1fns | %% <= %.1fns | %% > %.1fns),"
+          "DRAM (%%),DRAM latencies (%% <= %.1fns | %% <= %.1fns | %% <= %.1fns | %% > %.1fns),"
+          "Location:Line,Source Line,Function,Assembly\n",
+          cpu_system_config.latency_limits.l1_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l2_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l1_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l2_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l1_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l2_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l1_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l2_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0,
+          cpu_system_config.latency_limits.l3_latency_cap_ps / 1000.0);
+
+  // Don't want to crash in case other reports have entries
+  if (entries == NULL || count == 0) {
+    fprintf(stderr, "No entries to process\n");
+    fclose(exec_fp);
+    fclose(issue_fp);
+    fclose(translation_fp);
+    fclose(completion_fp);
+    return;
+  }
+
+  write_lat_map_sub_report(entries, count, exec_fp, compare_lat_exec_entries, print_exec_latency);
+  write_lat_map_sub_report(entries, count, issue_fp, compare_lat_issue_entries,
+                           print_issue_latency);
+  write_lat_map_sub_report(entries, count, translation_fp, compare_translation_issue_entries,
+                           print_translation_latency);
+  write_lat_map_sub_report(entries, count, completion_fp, compare_completion_node_issue_entries,
+                           print_completion_node);
+
+  fclose(exec_fp);
+  fclose(issue_fp);
+  fclose(translation_fp);
+  fclose(completion_fp);
+}
+
+/// @brief Wrapper exposed for APerf to call. Complementary to
+/// hotline.c/serialize_maps. Expands the maps and builds individual views.
+/// @param argc C-like number of arguments
+/// @param argv C-like pointer to argument
+/// @return 0 on success, -1 otherwise
+int deserialize_maps(int argc, char *argv[]) {
+  init_fname_binary_btree();
+  init_sys_info();  // this will give us access to our latency metrics
+  parse_arguments(argc, argv);
+
+  uint64_t count;
+
+  // For bmiss map data
+  // For bmiss map data
+  size_t bmiss_len = strlen(profile_configuration.data_dir) +
+                     strlen(profile_configuration.bmiss_map_filename) + 2;  // +2 for '/' and '\0'
+
+  char *bmiss_data_path = malloc(bmiss_len);
+  if (!bmiss_data_path) {
+    perror("Failed to allocate memory for bmiss path");
+    return -1;
+  }
+
+  int res = snprintf(bmiss_data_path, bmiss_len, "%s/%s", profile_configuration.data_dir,
+                     profile_configuration.bmiss_map_filename);
+
+  ASSERT(res > 0, "snprintf failed.");
+
+  // Process bmiss entries
+  bmiss_map_entry_t *b_entries = deserialize_bmiss_map(bmiss_data_path, &count);
+  generate_bmiss_report(profile_configuration.data_dir, b_entries, count);
+  free(bmiss_data_path);
+
+  // For lat map data
+  size_t lat_len =
+      strlen(profile_configuration.data_dir) + strlen(profile_configuration.lat_map_filename) + 2;
+  char *lat_data_path = malloc(lat_len);
+  if (!lat_data_path) {
+    perror("Failed to allocate memory for lat path");
+    return -1;
+  }
+  res = snprintf(lat_data_path, lat_len, "%s/%s", profile_configuration.data_dir,
+                 profile_configuration.lat_map_filename);
+  ASSERT(res > 0, "snprintf failed.");
+
+  // Process lat entries
+  lat_map_entry_t *l_entries = deserialize_lat_map(lat_data_path, &count);
+  generate_lat_report(profile_configuration.data_dir, l_entries, count);
+  free(lat_data_path);
+  return 0;
+}

--- a/src/hotline/report.h
+++ b/src/hotline/report.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "bmiss_map.h"
+#include "fname_binary_map.h"
+#include "lat_map.h"
+
+bmiss_map_entry_t *deserialize_bmiss_map(const char *filename, uint64_t *out_count);
+void generate_bmiss_report(const char *filepath, bmiss_map_entry_t *entries, uint64_t count);
+
+lat_map_entry_t *deserialize_lat_map(const char *filename, uint64_t *out_count);
+
+void generate_lat_report(const char *filepath, lat_map_entry_t *entries, uint64_t count);
+
+int deserialize_maps(int argc, char *argv[]);

--- a/src/hotline/sys.c
+++ b/src/hotline/sys.c
@@ -1,0 +1,162 @@
+#include "sys.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "log.h"
+
+cpu_system_configuration_t cpu_system_config;
+
+/// @brief Opens a file descriptor to cpuinfo
+/// @return File Descriptor
+FILE *open_cpu_info() {
+  FILE *fp;
+  fp = fopen("/proc/cpuinfo", "r");
+  ASSERT(fp != NULL, "Error opening /proc/cpuinfo.");
+  return fp;
+}
+
+/// @brief Uses the CPU file descriptor to read in the CPU part, so we can
+/// assign latency bins
+/// @return CPU part
+uint64_t get_cpu_part() {
+  FILE *fp = open_cpu_info();
+  uint64_t part = CPU_PART_ID_GRV4;  // default to GRV4 if no part is found
+
+  char line[256];
+  while (fgets(line, sizeof(line), fp) != NULL) {
+    if (sscanf(line, "CPU part\t: 0x%lx", &part) == 1) {
+      break;
+    }
+  }
+
+  fclose(fp);
+  return part;
+}
+
+/// @brief Wrapper for page size to standardize everything
+uint64_t get_page_size() {
+  int page_sz = sysconf(_SC_PAGE_SIZE);
+  ASSERT(page_sz != -1, "Failed to get page size.");
+  return (uint64_t)page_sz;
+}
+
+/// @brief Gets the frequency of the machine in Hz using dmidecode
+/// @return CPU Frequency in Hz
+uint64_t get_frequency() {
+  switch (get_cpu_part()) {
+    case CPU_PART_ID_GRV2:
+      return CPU_FREQ_GRV2;
+    case CPU_PART_ID_GRV3:
+      return CPU_FREQ_GRV3;
+    case CPU_PART_ID_GRV4:
+      return CPU_FREQ_GRV4;
+    default:
+      ASSERT(false, "Unkown part ID");
+  }
+}
+
+/// @brief Wrapper to get num CPUs
+uint64_t get_num_cpus() {
+  int part = sysconf(_SC_NPROCESSORS_ONLN);
+  ASSERT(part != -1, "Failed to get num CPUs.");
+  return (uint64_t)part;
+}
+
+/// @brief Read the part number to bin latencies, which are later used for
+///        histogramming data. Time granularity is picosecond so we preserve
+///        the decimal in the ns, but don't cause unecessary floating point ops
+///        or lose precision for larger amounts of samples. Picoseconds are also
+///        well under the limit and won't saturate the counters for our use cases.
+/// @param limits Bin to populate
+void get_latency_bins(completion_latency_limits_t *limits) {
+  uint64_t part = get_cpu_part();
+
+  // These latencies were gathered from lat_mem_rd
+  switch (part) {
+    case CPU_PART_ID_GRV2:
+      limits->l1_latency_cap_ps = 1800;   // 1.8 ns
+      limits->l2_latency_cap_ps = 5700;   // 5.7 ns
+      limits->l3_latency_cap_ps = 34000;  // 34 ns
+      break;
+    case CPU_PART_ID_GRV3:
+      limits->l1_latency_cap_ps = 1800;   // 1.8 ns
+      limits->l2_latency_cap_ps = 5700;   // 5.7 ns
+      limits->l3_latency_cap_ps = 34000;  // 34 ns
+      break;
+    case CPU_PART_ID_GRV4:
+      limits->l1_latency_cap_ps = 1500;   // 1.5 ns
+      limits->l2_latency_cap_ps = 5000;   // 5.0 ns
+      limits->l3_latency_cap_ps = 31000;  // 31 ns
+      break;
+    default:
+      ASSERT(0, "Unknown CPU part.");
+      break;
+  }
+}
+
+/// @brief Configures the perf_event_open type, which is dependent on CPU generation
+/// @return Perf type
+uint64_t get_perf_event_type() {
+  FILE *f = fopen("/sys/devices/arm_spe_0/type", "r");
+  ASSERT(f != NULL, "Failed to open ARM SPE type file");
+
+  char buffer[32];
+  ASSERT(fgets(buffer, sizeof(buffer), f) != NULL, "Failed to read SPE type");
+
+  fclose(f);
+
+  errno = 0;
+  uint64_t type = strtoull(buffer, NULL, 10);
+  ASSERT(errno == 0, "Failed to convert SPE type to integer");
+
+  return type;
+}
+
+/// @brief Initializes global CPU_SYSTEM_CONFIG struct
+void init_sys_info() {
+  cpu_system_config.cpu_part = get_cpu_part();
+  cpu_system_config.frequency = get_frequency();
+  cpu_system_config.page_size = get_page_size();
+  cpu_system_config.num_cpus = get_num_cpus();
+
+  get_latency_bins(&cpu_system_config.latency_limits);
+  cpu_system_config.perf_event_type = get_perf_event_type();
+  cpu_system_config.cyc_to_ps_conv_factor = SECOND_TO_PS / cpu_system_config.frequency;
+}
+
+/// @brief Returns the inode information associated with a file. Used for
+/// initial mappings for /proc/maps
+/// @param filename Filename to get information of
+/// @param finode finode_t struct to populate
+void get_file_info(const char *filename, finode_t *finode) {
+  // Handle special cases
+  if (strncmp(filename, "anon_inode:", 11) == 0 || filename[0] == '[') {
+    finode->ino = 0;
+    finode->maj = 0;
+    finode->min = 0;
+    finode->ino_generation = 0;
+    return;
+  }
+
+  struct stat sb;
+  if (lstat(filename, &sb) == -1) {
+    finode->ino = 0;
+    finode->maj = 0;
+    finode->min = 0;
+    finode->ino_generation = 0;
+    return;
+  }
+
+  // General case
+  finode->ino = sb.st_ino;
+  dev_t dev = sb.st_dev;  // device containing the file
+  finode->maj = major(dev);
+  finode->min = minor(dev);
+  finode->ino_generation = 0;
+}

--- a/src/hotline/sys.h
+++ b/src/hotline/sys.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "finode_map.h"
+
+#define CPU_FREQ_GRV2 2500000000  // 2.5 GHz
+#define CPU_PART_ID_GRV2 0xd0c
+
+#define CPU_FREQ_GRV3 2600000000  // 2.6 GHz
+#define CPU_PART_ID_GRV3 0xd40
+
+#define CPU_FREQ_GRV4 2800000000  // 2.8 GHz
+#define CPU_PART_ID_GRV4 0xd4f
+
+#define SECOND_TO_PS 1000000000000
+
+/// @brief Bins for grouping latencies by completion node
+typedef struct completion_latency_limits {
+  uint64_t l1_latency_cap_ps;
+  uint64_t l2_latency_cap_ps;
+  uint64_t l3_latency_cap_ps;
+} completion_latency_limits_t;
+
+/// @brief Global struct to access system configuration
+typedef struct cpu_system_configuration {
+  uint64_t cpu_part;
+  uint64_t page_size;
+  uint64_t frequency;
+  uint64_t num_cpus;
+  completion_latency_limits_t latency_limits;
+  uint64_t perf_event_type;
+  uint64_t cyc_to_ps_conv_factor;
+} cpu_system_configuration_t;
+
+void init_sys_info();
+void get_file_info(const char *filename, finode_t *finode);
+
+/// @brief Exposed global system configuration for other modules to use
+extern cpu_system_configuration_t cpu_system_config;

--- a/src/hotline/tests/test.c
+++ b/src/hotline/tests/test.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void test_bmiss_map();
+void test_lat_map();
+void test_fname_map();
+void test_finode_map();
+void test_fname_binary_map();
+void test_config();
+
+void test_all() {
+  test_bmiss_map();
+  test_lat_map();
+  test_finode_map();
+  test_fname_binary_map();
+  test_config();
+}

--- a/src/hotline/tests/test.h
+++ b/src/hotline/tests/test.h
@@ -1,0 +1,19 @@
+#ifndef TEST_HEADERS_H_
+#define TEST_HEADERS_H_
+
+#include "../bmiss_map.h"
+#include "../btree.h"
+#include "../config.h"
+#include "../finode_map.h"
+#include "../fname_binary_map.h"
+#include "../fname_map.h"
+#include "../hotline.h"
+#include "../lat_map.h"
+#include "../perf_interface.h"
+#include "../report.h"
+#include "../sys.h"
+#include "../vec.h"
+
+void test_all();
+
+#endif  // TEST_HEADERS_H_

--- a/src/hotline/tests/test_bmiss_map.c
+++ b/src/hotline/tests/test_bmiss_map.c
@@ -1,0 +1,147 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test.h"
+
+// Test init_bmiss_map function
+void test_init_bmiss_map() {
+  init_bmiss_map();
+  assert(bmiss_map != NULL);
+}
+
+// Test insert_bmiss_map function
+void test_insert_bmiss_map() {
+  init_bmiss_map();
+
+  // Test inserting new entry
+  bmiss_map_entry_t entry = {0};
+  entry.finode.ino = 100;
+  entry.finode.maj = 1;
+  entry.finode.min = 2;
+  entry.finode.ino_generation = 3;
+  entry.offset = 1000;
+  entry.count = 1;
+  entry.mispredicted = 1;
+  entry.branch_type = AUX_RECORD_TYPE_BCOND;
+
+  insert_bmiss_map(&entry);
+
+  // Verify entry was inserted
+  bmiss_map_entry_t key = {.finode = entry.finode, .offset = entry.offset};
+  const bmiss_map_entry_t *result = btree_get(bmiss_map, &key);
+  assert(result != NULL);
+  assert(result->count == 1);
+  assert(result->mispredicted == 1);
+  assert(result->branch_type == AUX_RECORD_TYPE_BCOND);
+
+  // Test updating existing entry
+  bmiss_map_entry_t update_entry = entry;
+  update_entry.count = 1;
+  update_entry.mispredicted = 0;
+
+  insert_bmiss_map(&update_entry);
+
+  // Verify entry was updated (aggregated)
+  result = btree_get(bmiss_map, &key);
+  assert(result != NULL);
+  assert(result->count == 2);         // 1 + 1
+  assert(result->mispredicted == 1);  // 1 + 0
+
+  // Verify original entry was not affected
+  result = btree_get(bmiss_map, &key);
+  assert(result != NULL);
+}
+
+// Test parse_bmiss_map_entry function
+void test_parse_bmiss_map_entry() {
+  // Test normal record parsing
+  spe_record_raw_t record = {0};
+  record.total_lat = 100;
+  record.issue_lat = 60;
+  record.events_packet = AUX_EVENT_BRANCH_MISS;
+  record.type = AUX_RECORD_TYPE_BCOND;
+
+  finode_t finode = {.ino = 200, .maj = 3, .min = 4, .ino_generation = 5};
+  uint64_t offset = 2000;
+
+  bmiss_map_entry_t entry = {0};
+  parse_bmiss_map_entry(&record, &entry, &finode, offset);
+
+  assert(entry.finode.ino == 200);
+  assert(entry.finode.maj == 3);
+  assert(entry.finode.min == 4);
+  assert(entry.finode.ino_generation == 5);
+  assert(entry.offset == 2000);
+  assert(entry.count == 1);
+  assert(entry.branch_type == AUX_RECORD_TYPE_BCOND);
+
+  // Test saturated record parsing
+  spe_record_raw_t saturated_record = {0};
+  saturated_record.issue_lat = AUX_PACKET_SATURATED;
+  saturated_record.total_lat = 200;
+  saturated_record.events_packet = AUX_EVENT_BRANCH_NOT_TAKEN;
+
+  bmiss_map_entry_t saturated_entry = {0};
+  parse_bmiss_map_entry(&saturated_record, &saturated_entry, &finode, offset);
+
+  assert(saturated_entry.mispredicted == 0);  // Should not update when saturated
+
+  // Test branch not taken parsing
+  spe_record_raw_t not_taken_record = {0};
+  not_taken_record.issue_lat = 40;
+  not_taken_record.total_lat = 80;
+  not_taken_record.events_packet = AUX_EVENT_BRANCH_NOT_TAKEN;
+
+  bmiss_map_entry_t not_taken_entry = {0};
+  parse_bmiss_map_entry(&not_taken_record, &not_taken_entry, &finode, offset);
+
+  assert(not_taken_entry.mispredicted == 0);
+  assert(not_taken_entry.count == 1);
+}
+
+// Test integration scenario
+void test_bmiss_integration() {
+  init_bmiss_map();
+
+  // Simulate processing multiple SPE records for the same location
+  spe_record_raw_t record1 = {0};
+  record1.total_lat = 50;
+  record1.issue_lat = 30;
+  record1.type = AUX_RECORD_TYPE_BCOND;
+
+  spe_record_raw_t record2 = {0};
+  record2.total_lat = 70;
+  record2.issue_lat = 40;
+  record2.events_packet = AUX_EVENT_BRANCH_MISS;
+  record2.type = AUX_RECORD_TYPE_BCOND;
+
+  finode_t finode = {.ino = 300, .maj = 5, .min = 6, .ino_generation = 7};
+  uint64_t offset = 3000;
+
+  // Parse and insert first record
+  bmiss_map_entry_t entry1 = {0};
+  parse_bmiss_map_entry(&record1, &entry1, &finode, offset);
+  insert_bmiss_map(&entry1);
+
+  // Parse and insert second record (same location)
+  bmiss_map_entry_t entry2 = {0};
+  parse_bmiss_map_entry(&record2, &entry2, &finode, offset);
+  insert_bmiss_map(&entry2);
+
+  // Verify aggregated results
+  bmiss_map_entry_t key = {.finode = finode, .offset = offset};
+  const bmiss_map_entry_t *result = btree_get(bmiss_map, &key);
+  assert(result != NULL);
+  assert(result->count == 2);         // 1 + 0
+  assert(result->mispredicted == 1);  // 0 + 1
+}
+
+void test_bmiss_map() {
+  // test_bmiss_map_compare();
+  test_init_bmiss_map();
+  test_insert_bmiss_map();
+  test_parse_bmiss_map_entry();
+  test_bmiss_integration();
+}

--- a/src/hotline/tests/test_config.c
+++ b/src/hotline/tests/test_config.c
@@ -1,0 +1,92 @@
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test.h"
+
+void test_init() { cpu_system_config.page_size = 4096; }
+
+void test_parse_arguments_defaults() {
+  // Reset getopt's global state
+  optind = 1;  // Reset to 1 before parsing arguments
+
+  char *argv[] = {"test_program"};
+  int argc = 1;
+
+  parse_arguments(argc, argv);
+
+  assert(profile_configuration.wakeup_period == PROFILE_DEFAULT_WAKEUP_PERIOD);
+  assert(profile_configuration.hotline_frequency == PROFILE_DEFAULT_SPE_SAMPLE_FREQ);
+  assert(profile_configuration.timeout == PROFILE_DEFAULT_TIMEOUT);
+  assert(profile_configuration.num_to_report == PROFILE_DEFAULT_NUM_REPORT);
+  assert(strcmp(profile_configuration.data_dir, "./data") == 0);
+}
+
+void test_parse_arguments_custom() {
+  // Reset getopt's global state
+  optind = 1;  // Reset to 1 before parsing arguments
+
+  char *argv[] = {"test_program", "--wakeup_period", "5",  "--hotline_frequency",
+                  "2000",         "--timeout",       "30", "--data_dir",
+                  "/tmp/data"};
+  int argc = 9;
+
+  parse_arguments(argc, argv);
+
+  assert(profile_configuration.wakeup_period == 5);
+  assert(profile_configuration.hotline_frequency == 2000);
+  assert(profile_configuration.timeout == 30);
+  assert(strcmp(profile_configuration.data_dir, "/tmp/data") == 0);
+}
+
+void test_get_perf_buffer_sizes() {
+  // Set up configuration
+  profile_configuration.wakeup_period = 2;
+  profile_configuration.hotline_frequency = 1000;
+
+  perf_buffer_size_t buffer_sizes;
+  get_perf_buffer_sizes(&buffer_sizes);
+
+  // Verify calculations
+  uint64_t raw_record_size = 16 * cpu_system_config.page_size * sizeof(switch_cpu_wide_record_t) *
+                             profile_configuration.wakeup_period;
+  uint64_t expected_record_buf =
+      (uint64_t)pow(2, ceil(log2((double)raw_record_size))) + cpu_system_config.page_size;
+
+  uint64_t expected_aux_buf_raw = profile_configuration.hotline_frequency *
+                                  profile_configuration.wakeup_period * sizeof(spe_record_raw_t) *
+                                  4;
+
+  assert(buffer_sizes.perf_record_buf_sz == expected_record_buf);
+  assert(buffer_sizes.perf_aux_off == expected_record_buf + cpu_system_config.page_size);
+  assert(buffer_sizes.perf_aux_buf_sz >= expected_aux_buf_raw);
+  assert((buffer_sizes.perf_aux_buf_sz & (buffer_sizes.perf_aux_buf_sz - 1)) == 0);
+}
+
+void test_get_perf_buffer_sizes_different_config() {
+  profile_configuration.wakeup_period = 1;
+  profile_configuration.hotline_frequency = 500;
+
+  perf_buffer_size_t buffer_sizes;
+  get_perf_buffer_sizes(&buffer_sizes);
+
+  uint64_t raw_record_size = 16 * cpu_system_config.page_size * sizeof(switch_cpu_wide_record_t) *
+                             profile_configuration.wakeup_period;
+  uint64_t expected_record_buf =
+      (uint64_t)pow(2, ceil(log2((double)raw_record_size))) + cpu_system_config.page_size;
+
+  assert(buffer_sizes.perf_record_buf_sz == expected_record_buf);
+  assert(buffer_sizes.perf_aux_off == expected_record_buf + cpu_system_config.page_size);
+  assert((buffer_sizes.perf_aux_buf_sz & (buffer_sizes.perf_aux_buf_sz - 1)) == 0);
+}
+
+void test_config() {
+  test_init();
+
+  test_parse_arguments_defaults();
+  test_parse_arguments_custom();
+  test_get_perf_buffer_sizes();
+  test_get_perf_buffer_sizes_different_config();
+}

--- a/src/hotline/tests/test_finode_map.c
+++ b/src/hotline/tests/test_finode_map.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test.h"
+
+void test_init_finode_map() {
+  init_finode_map();
+  assert(finode_map != NULL);
+}
+
+void test_insert_finode_entry() {
+  init_finode_map();
+
+  const char *test_filename = "/test/file";
+  size_t filename_len = strlen(test_filename) + 1;  // +1 for null terminator
+  size_t record_size = sizeof(mmap2_record_t) + filename_len;
+
+  // Allocate memory for the entire structure including the flexible array
+  // member
+  mmap2_record_t *record = malloc(record_size);
+  if (record == NULL) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
+
+  // Initialize the structure
+  memset(record, 0, record_size);
+  record->pid = 1234;
+  record->addr = 0x400000;
+  record->len = 0x1000;
+  record->pgoff = 0;
+  record->ino = 123;
+  record->maj = 8;
+  record->min = 1;
+  record->ino_generation = 1;
+
+  strcpy(record->filename, test_filename);
+
+  insert_finode_entry(record);
+
+  // Verify entry exists
+  finode_map_entry_t key = {{.ino = 123, .maj = 8, .min = 1, .ino_generation = 1}, NULL};
+  const finode_map_entry_t *entry = btree_get(finode_map, &key);
+  assert(entry != NULL);
+  assert(entry->finode.ino == 123);
+  assert(strcmp(entry->filename, "/test/file") == 0);
+}
+
+void test_finode_map() {
+  test_init_finode_map();
+  test_insert_finode_entry();
+}

--- a/src/hotline/tests/test_fname_binary_map.c
+++ b/src/hotline/tests/test_fname_binary_map.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test.h"
+
+void test_init_fname_binary_btree() {
+  init_fname_binary_btree();
+  // Just ensure it doesn't crash
+}
+
+void test_get_absolute_source_path() {
+  // Test absolute path
+  char *result = get_absolute_source_path("/bin/test", "/usr/src/file.c");
+  assert(result != NULL);
+  assert(strcmp(result, "/usr/src/file.c") == 0);
+  free(result);
+
+  // Test relative path
+  result = get_absolute_source_path("/bin/test", "src/file.c");
+  assert(result != NULL);
+  // Should contain the relative path resolved
+  assert(strstr(result, "src/file.c") != NULL);
+  free(result);
+
+  // Test NULL source path
+  result = get_absolute_source_path("/bin/test", NULL);
+  assert(result == NULL);
+}
+
+void test_get_line_at_line_number() {
+  // Create a temporary test file
+  FILE *temp = tmpfile();
+  assert(temp != NULL);
+
+  fprintf(temp, "line 1\n");
+  fprintf(temp, "line 2\n");
+  fprintf(temp, "line 3\n");
+  rewind(temp);
+
+  // Get temp file path (this is tricky with tmpfile, so we'll test with
+  // /dev/null)
+  char *result = get_line_at_line_number("/dev/null", 1);
+  // Should return NULL for /dev/null
+  assert(result == NULL);
+
+  fclose(temp);
+}
+
+void test_fname_binary_map() {
+  test_init_fname_binary_btree();
+  test_get_absolute_source_path();
+  test_get_line_at_line_number();
+}

--- a/src/hotline/tests/test_fname_map.c
+++ b/src/hotline/tests/test_fname_map.c
@@ -1,0 +1,199 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test.h"
+
+void test_init_fname_map() {
+  // Don't actually init it because we don't want to populate it with /proc.
+  // This will synthetically init the B-Tree for testing.
+  fname_map = btree_new(sizeof(filename_entry_t), 0, fname_compare, NULL);
+  btree_clear(fname_map);
+  assert(fname_map != NULL);
+}
+
+void test_insert_fname_entry() {
+  test_init_fname_map();
+
+  // Create mock MMAP2 record
+  const char *test_filename = "/test/binary";
+  size_t filename_len = strlen(test_filename) + 1;  // +1 for null terminator
+  size_t record_size = sizeof(mmap2_record_t) + filename_len;
+
+  // Allocate memory for the entire structure including the flexible array
+  // member
+  mmap2_record_t *record = malloc(record_size);
+  if (record == NULL) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
+
+  // Initialize the structure
+  memset(record, 0, record_size);
+  record->pid = 1234;
+  record->addr = 0x400000;
+  record->len = 0x1000;
+  record->pgoff = 0;
+  record->ino = 100;
+  record->maj = 8;
+  record->min = 1;
+  record->ino_generation = 1;
+
+  // Copy the filename into the flexible array member
+  strcpy(record->filename, test_filename);
+
+  // Use the record...
+  insert_fname_entry(record);
+
+  // Free the allocated memory when done
+  free(record);
+
+  // Verify entry exists
+  filename_entry_t key = {.pid = 1234};
+  const filename_entry_t *entry = btree_get(fname_map, &key);
+  assert(entry != NULL);
+  assert(entry->pid == 1234);
+  assert(entry->virtual_address_map != NULL);
+}
+
+void test_va_to_file_offset() {
+  test_init_fname_map();
+
+  // Insert test mapping
+  size_t filename_len = strlen("/test/lib.so") + 1;  // +1 for null terminator
+  size_t record_size = sizeof(mmap2_record_t) + filename_len;
+
+  mmap2_record_t *record = malloc(record_size);
+  if (record == NULL) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
+
+  // Initialize the structure
+  memset(record, 0, record_size);
+  record->pid = 5678;
+  record->addr = 0x400000;
+  record->len = 0x2000;
+  record->pgoff = 0;
+  record->ino = 100;
+  record->maj = 8;
+  record->min = 1;
+  record->ino_generation = 1;
+
+  // Copy the filename into the flexible array member
+  strcpy(record->filename, "/test/lib.so");
+
+  insert_fname_entry(record);
+
+  // Test successful mapping
+  finode_t finode;
+  uint64_t offset;
+  int result = va_to_file_offset(0x401000, 5678, &finode, &offset);
+
+  assert(result == 0);
+  assert(finode.ino == 100);
+  assert(finode.maj == 8);
+  assert(finode.min == 1);
+  assert(offset == 0x1000);  // 0x401000 - 0x400000 + 0x1000
+
+  // Test address outside range
+  result = va_to_file_offset(0x500000, 5678, &finode, &offset);
+  assert(result == -1);
+
+  // Test non-existent PID
+  result = va_to_file_offset(0x401000, 9999, &finode, &offset);
+  assert(result == -1);
+}
+
+void test_remove_fname_entry() {
+  test_init_fname_map();
+
+  // Insert test mapping
+  size_t filename_len = strlen("/test/lib.so") + 1;  // +1 for null terminator
+  size_t record_size = sizeof(mmap2_record_t) + filename_len;
+
+  mmap2_record_t *record = malloc(record_size);
+  if (record == NULL) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
+
+  // Initialize the structure
+  memset(record, 0, record_size);
+  record->pid = 5678;
+  record->addr = 0x400000;
+  record->len = 0x2000;
+  record->pgoff = 0;
+  record->ino = 100;
+  record->maj = 8;
+  record->min = 1;
+  record->ino_generation = 1;
+
+  // Copy the filename into the flexible array member
+  strcpy(record->filename, "/test/lib.so");
+
+  insert_fname_entry(record);
+
+  // Verify entry exists
+  filename_entry_t key = {.pid = 5678};
+  const filename_entry_t *entry = btree_get(fname_map, &key);
+  assert(entry != NULL);
+
+  // Remove entry
+  remove_fname_entry(5678);
+
+  // Verify entry is gone
+  entry = btree_get(fname_map, &key);
+  assert(entry == NULL);
+}
+
+void test_cache_functionality() {
+  test_init_fname_map();
+
+  // Insert test mapping
+  size_t filename_len = strlen("/test/lib.so") + 1;  // +1 for null terminator
+  size_t record_size = sizeof(mmap2_record_t) + filename_len;
+
+  mmap2_record_t *record = malloc(record_size);
+  if (record == NULL) {
+    fprintf(stderr, "Memory allocation failed\n");
+    return;
+  }
+
+  // Initialize the structure
+  memset(record, 0, record_size);
+  record->pid = 2222;
+  record->addr = 0x400000;
+  record->len = 0x9000;
+  record->pgoff = 0;
+  record->ino = 100;
+  record->maj = 8;
+  record->min = 1;
+  record->ino_generation = 1;
+
+  // Copy the filename into the flexible array member
+  strcpy(record->filename, "/test/lib.so");
+
+  insert_fname_entry(record);
+
+  // First lookup should cache the entry
+  finode_t finode;
+  uint64_t offset;
+  int result = va_to_file_offset(0x400500, 2222, &finode, &offset);
+  assert(result == 0);
+
+  // Second lookup should use cache
+  result = va_to_file_offset(0x400600, 2222, &finode, &offset);
+  assert(result == 0);
+  assert(offset == 0x600);
+}
+
+void test_fname_map() {
+  test_init_fname_map();
+  test_insert_fname_entry();
+  test_va_to_file_offset();
+  test_remove_fname_entry();
+  test_cache_functionality();
+}

--- a/src/hotline/tests/test_lat_map.c
+++ b/src/hotline/tests/test_lat_map.c
@@ -1,0 +1,203 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test.h"
+
+// Test init_lat_map function
+void test_init_lat_map() {
+  cpu_system_config.latency_limits.l1_latency_cap_ps = 10;
+  cpu_system_config.latency_limits.l2_latency_cap_ps = 50;
+  cpu_system_config.latency_limits.l3_latency_cap_ps = 200;
+  cpu_system_config.cyc_to_ps_conv_factor = 1;
+
+  init_lat_map();
+  assert(lat_map != NULL);
+}
+
+// Test insert_lat_map_entry function
+void test_insert_lat_map_entry() {
+  init_lat_map();
+
+  // Test inserting new entry
+  lat_map_entry_t entry = {0};
+  entry.finode.ino = 100;
+  entry.finode.maj = 1;
+  entry.finode.min = 2;
+  entry.finode.ino_generation = 3;
+  entry.offset = 1000;
+  entry.total_latency = 100;
+  entry.issue_latency = 60;
+  entry.translation_latency = 20;
+  entry.saturated = 1;
+  entry.count = 1;
+  entry.l1.l1_bound_bin = 5;
+  entry.l2.l2_bound_bin = 3;
+
+  insert_lat_map_entry(&entry);
+
+  // Verify entry was inserted
+  lat_map_entry_t key = {.finode = entry.finode, .offset = entry.offset};
+  const lat_map_entry_t *result = btree_get(lat_map, &key);
+  assert(result != NULL);
+  assert(result->total_latency == 100);
+  assert(result->issue_latency == 60);
+  assert(result->translation_latency == 20);
+  assert(result->saturated == 1);
+  assert(result->count == 1);
+  assert(result->l1.l1_bound_bin == 5);
+  assert(result->l2.l2_bound_bin == 3);
+
+  // Test updating existing entry
+  lat_map_entry_t update_entry = entry;
+  update_entry.total_latency = 50;
+  update_entry.issue_latency = 30;
+  update_entry.translation_latency = 10;
+  update_entry.saturated = 2;
+  update_entry.count = 1;
+  update_entry.l1.l1_bound_bin = 2;
+  update_entry.l2.l2_bound_bin = 1;
+
+  insert_lat_map_entry(&update_entry);
+
+  // Verify entry was updated (aggregated)
+  result = btree_get(lat_map, &key);
+  assert(result != NULL);
+  assert(result->total_latency == 150);       // 100 + 50
+  assert(result->issue_latency == 90);        // 60 + 30
+  assert(result->translation_latency == 30);  // 20 + 10
+  assert(result->saturated == 3);             // 1 + 2
+  assert(result->count == 2);                 // 1 + 1
+  assert(result->l1.l1_bound_bin == 7);       // 5 + 2
+  assert(result->l2.l2_bound_bin == 4);       // 3 + 1
+}
+
+// Test parse_lat_map_entry function
+void test_parse_lat_map_entry() {
+  // Test NULL inputs
+  finode_t finode = {.ino = 200, .maj = 3, .min = 4, .ino_generation = 5};
+  uint64_t offset = 2000;
+  lat_map_entry_t entry = {0};
+  spe_record_raw_t record = {0};
+
+  parse_lat_map_entry(NULL, &entry, &finode, offset);
+  assert(entry.total_latency == 0);
+
+  parse_lat_map_entry(&record, NULL, &finode, offset);
+  parse_lat_map_entry(&record, &entry, NULL, offset);
+
+  // Test L1 data source with L1-bound latency
+  record.total_lat = 100;
+  record.issue_lat = 60;
+  record.x_lat = 20;
+  record.data_source = DATA_SOURCE_L1;
+  record.events_packet = AUX_EVENT_RETIRED;
+
+  parse_lat_map_entry(&record, &entry, &finode, offset);
+
+  assert(entry.finode.ino == 200);
+  assert(entry.total_latency == 100);
+  assert(entry.issue_latency == 60);
+  assert(entry.translation_latency == 20);
+  assert(entry.saturated == 0);
+  assert(entry.count == 1);
+  assert(entry.l1.l1_bound_bin == 0);  // execution_latency = 20, <= 10 is false, <= 50 is true
+  assert(entry.l1.l2_bound_bin == 1);
+
+  // Test DRAM data source with DRAM-bound latency
+  spe_record_raw_t dram_record = {0};
+  dram_record.total_lat = 500;
+  dram_record.issue_lat = 50;
+  dram_record.x_lat = 30;
+  dram_record.data_source = DATA_SOURCE_DRAM;
+
+  lat_map_entry_t dram_entry = {0};
+  parse_lat_map_entry(&dram_record, &dram_entry, &finode, offset);
+
+  assert(dram_entry.dram.dram_bound_bin == 1);  // execution_latency = 420, > 200
+  assert(dram_entry.dram.l1_bound_bin == 0);
+  assert(dram_entry.dram.l2_bound_bin == 0);
+  assert(dram_entry.dram.l3_bound_bin == 0);
+
+  // Test saturated record
+  spe_record_raw_t saturated_record = {0};
+  saturated_record.issue_lat = AUX_PACKET_SATURATED;
+  saturated_record.total_lat = 200;
+
+  lat_map_entry_t saturated_entry = {0};
+  parse_lat_map_entry(&saturated_record, &saturated_entry, &finode, offset);
+
+  assert(saturated_entry.saturated == 1);
+  assert(saturated_entry.total_latency == 0);  // Should not update when saturated
+  assert(saturated_entry.issue_latency == 0);
+
+  // Test L3 data source (system cache)
+  spe_record_raw_t l3_record = {0};
+  l3_record.total_lat = 150;
+  l3_record.issue_lat = 40;
+  l3_record.x_lat = 10;
+  l3_record.data_source = DATA_SOURCE_SYSTEM_CACHE;
+
+  lat_map_entry_t l3_entry = {0};
+  parse_lat_map_entry(&l3_record, &l3_entry, &finode, offset);
+
+  assert(l3_entry.l3.l3_bound_bin == 1);  // execution_latency = 100, <= 200 but > 50
+
+  // Test invalid data source
+  spe_record_raw_t invalid_record = {0};
+  invalid_record.data_source = 99;  // Invalid value
+  lat_map_entry_t invalid_entry = {0};
+  parse_lat_map_entry(&invalid_record, &invalid_entry, &finode, offset);
+  assert(invalid_entry.total_latency == 0);
+}
+
+// Test integration scenario
+void test_lat_integration() {
+  init_lat_map();
+
+  // Simulate processing multiple SPE records for the same location
+  spe_record_raw_t record1 = {0};
+  record1.total_lat = 80;
+  record1.issue_lat = 40;
+  record1.x_lat = 10;
+  record1.data_source = DATA_SOURCE_L1;
+  record1.events_packet = AUX_EVENT_RETIRED;
+
+  spe_record_raw_t record2 = {0};
+  record2.total_lat = 120;
+  record2.issue_lat = 60;
+  record2.x_lat = 20;
+  record2.data_source = DATA_SOURCE_L2;
+
+  finode_t finode = {.ino = 300, .maj = 5, .min = 6, .ino_generation = 7};
+  uint64_t offset = 3000;
+
+  // Parse and insert first record
+  lat_map_entry_t entry1 = {0};
+  parse_lat_map_entry(&record1, &entry1, &finode, offset);
+  insert_lat_map_entry(&entry1);
+
+  // Parse and insert second record (same location)
+  lat_map_entry_t entry2 = {0};
+  parse_lat_map_entry(&record2, &entry2, &finode, offset);
+  insert_lat_map_entry(&entry2);
+
+  // Verify aggregated results
+  lat_map_entry_t key = {.finode = finode, .offset = offset};
+  const lat_map_entry_t *result = btree_get(lat_map, &key);
+  assert(result != NULL);
+  assert(result->total_latency == 200);       // 80 + 120
+  assert(result->issue_latency == 100);       // 40 + 60
+  assert(result->translation_latency == 30);  // 10 + 20
+  assert(result->count == 2);                 // 1 + 1
+  assert(result->l1.l2_bound_bin == 1);       // First record: execution_latency = 30
+  assert(result->l2.l2_bound_bin == 1);       // Second record: execution_latency = 40
+}
+
+void test_lat_map() {
+  test_init_lat_map();
+  test_insert_lat_map_entry();
+  test_parse_lat_map_entry();
+  test_lat_integration();
+}

--- a/src/hotline/vec.c
+++ b/src/hotline/vec.c
@@ -1,0 +1,132 @@
+/*
+BSD 3-Clause License
+
+Copyright (c) 2024, Mashpoe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "vec.h"
+
+#include <string.h>
+
+typedef struct {
+  vec_size_t size;
+  vec_size_t capacity;
+  unsigned char data[];
+} vector_header;
+
+vector_header* vector_get_header(vector vec) { return &((vector_header*)vec)[-1]; }
+
+vector vector_create(void) {
+  vector_header* h = (vector_header*)malloc(sizeof(vector_header));
+  h->capacity = 0;
+  h->size = 0;
+
+  return &h->data;
+}
+
+void vector_free(vector vec) { free(vector_get_header(vec)); }
+
+vec_size_t vector_size(vector vec) { return vector_get_header(vec)->size; }
+
+vec_size_t vector_capacity(vector vec) { return vector_get_header(vec)->capacity; }
+
+vector_header* vector_realloc(vector_header* h, vec_type_t type_size) {
+  vec_size_t new_capacity = (h->capacity == 0) ? 1 : h->capacity * 2;
+  vector_header* new_h =
+      (vector_header*)realloc(h, sizeof(vector_header) + new_capacity * type_size);
+  new_h->capacity = new_capacity;
+
+  return new_h;
+}
+
+bool vector_has_space(vector_header* h) { return h->capacity - h->size > 0; }
+
+void* _vector_add_dst(vector* vec_addr, vec_type_t type_size) {
+  vector_header* h = vector_get_header(*vec_addr);
+
+  if (!vector_has_space(h)) {
+    h = vector_realloc(h, type_size);
+    *vec_addr = h->data;
+  }
+
+  return &h->data[type_size * h->size++];
+}
+
+void* _vector_insert_dst(vector* vec_addr, vec_type_t type_size, vec_size_t pos) {
+  vector_header* h = vector_get_header(*vec_addr);
+
+  vec_size_t new_length = h->size + 1;
+
+  // make sure there is enough room for the new element
+  if (!vector_has_space(h)) {
+    h = vector_realloc(h, type_size);
+    *vec_addr = h->data;
+  }
+  // move trailing elements
+  memmove(&h->data[(pos + 1) * type_size], &h->data[pos * type_size], (h->size - pos) * type_size);
+
+  h->size = new_length;
+
+  return &h->data[pos * type_size];
+}
+
+void _vector_erase(vector vec, vec_type_t type_size, vec_size_t pos, vec_size_t len) {
+  vector_header* h = vector_get_header(vec);
+  memmove(&h->data[pos * type_size], &h->data[(pos + len) * type_size],
+          (h->size - pos - len) * type_size);
+
+  h->size -= len;
+}
+
+void _vector_remove(vector vec, vec_type_t type_size, vec_size_t pos) {
+  _vector_erase(vec, type_size, pos, 1);
+}
+
+void vector_pop(vector vec) { --vector_get_header(vec)->size; }
+
+void _vector_reserve(vector* vec_addr, vec_type_t type_size, vec_size_t capacity) {
+  vector_header* h = vector_get_header(*vec_addr);
+  if (h->capacity >= capacity) {
+    return;
+  }
+
+  h = (vector_header*)realloc(h, sizeof(vector_header) + capacity * type_size);
+  h->capacity = capacity;
+  *vec_addr = &h->data;
+}
+
+vector _vector_copy(vector vec, vec_type_t type_size) {
+  vector_header* h = vector_get_header(vec);
+  size_t alloc_size = sizeof(vector_header) + h->size * type_size;
+  vector_header* copy_h = (vector_header*)malloc(alloc_size);
+  memcpy(copy_h, h, alloc_size);
+  copy_h->capacity = copy_h->size;
+
+  return &copy_h->data;
+}

--- a/src/hotline/vec.h
+++ b/src/hotline/vec.h
@@ -1,0 +1,116 @@
+/*
+BSD 3-Clause License
+
+Copyright (c) 2024, Mashpoe
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef vec_h
+#define vec_h
+
+#ifdef __cpp_decltype
+#include <type_traits>
+#define typeof(T) std::remove_reference<std::add_lvalue_reference<decltype(T)>::type>::type
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+// generic type for internal use
+typedef void* vector;
+// number of elements in a vector
+typedef size_t vec_size_t;
+// number of bytes for a type
+typedef size_t vec_type_t;
+
+// TODO: more rigorous check for typeof support with different compilers
+#if _MSC_VER == 0 || __STDC_VERSION__ >= 202311L || defined __cpp_decltype
+
+// shortcut defines
+
+// vec_addr is a vector* (aka type**)
+#define vector_add_dst(vec_addr) \
+  ((typeof(*vec_addr))(_vector_add_dst((vector*)vec_addr, sizeof(**vec_addr))))
+#define vector_insert_dst(vec_addr, pos) \
+  ((typeof(*vec_addr))(_vector_insert_dst((vector*)vec_addr, sizeof(**vec_addr), pos)))
+
+#define vector_add(vec_addr, value) (*vector_add_dst(vec_addr) = value)
+#define vector_insert(vec_addr, pos, value) (*vector_insert_dst(vec_addr, pos) = value)
+
+#else
+
+#define vector_add_dst(vec_addr, type) ((type*)_vector_add_dst((vector*)vec_addr, sizeof(type)))
+#define vector_insert_dst(vec_addr, type, pos) \
+  ((type*)_vector_insert_dst((vector*)vec_addr, sizeof(type), pos))
+
+#define vector_add(vec_addr, type, value) (*vector_add_dst(vec_addr, type) = value)
+#define vector_insert(vec_addr, type, pos, value) (*vector_insert_dst(vec_addr, type, pos) = value)
+
+#endif
+
+// vec is a vector (aka type*)
+#define vector_erase(vec, pos, len) (_vector_erase((vector)vec, sizeof(*vec), pos, len))
+#define vector_remove(vec, pos) (_vector_remove((vector)vec, sizeof(*vec), pos))
+
+#define vector_reserve(vec_addr, capacity) \
+  (_vector_reserve((vector*)vec_addr, sizeof(**vec_addr), capacity))
+
+#define vector_copy(vec) (_vector_copy((vector)vec, sizeof(*vec)))
+
+vector vector_create(void);
+
+void vector_free(vector vec);
+
+void* _vector_add_dst(vector* vec_addr, vec_type_t type_size);
+
+void* _vector_insert_dst(vector* vec_addr, vec_type_t type_size, vec_size_t pos);
+
+void _vector_erase(vector vec_addr, vec_type_t type_size, vec_size_t pos, vec_size_t len);
+
+void _vector_remove(vector vec_addr, vec_type_t type_size, vec_size_t pos);
+
+void vector_pop(vector vec);
+
+void _vector_reserve(vector* vec_addr, vec_type_t type_size, vec_size_t capacity);
+
+vector _vector_copy(vector vec, vec_type_t type_size);
+
+vec_size_t vector_size(vector vec);
+
+vec_size_t vector_capacity(vector vec);
+
+// closing bracket for extern "C"
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* vec_h */

--- a/src/html_files/hotline.ts
+++ b/src/html_files/hotline.ts
@@ -1,0 +1,102 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const memoryConfigs = [
+        {
+            id: 'completion_node',
+            title: 'Execution Latency by Completion Node',
+            description: 'The completion node view bins the memory operations by completion node (L1/L2/L3/DRAM) as reported by SPE and execution latency. The L1 % / L2 % / L3 % / DRAM % columns show the total percentage of packets that were identified with the respective completion node. Each completion node is further divided into a sub histogram, binning latencies by cutoffs determined from the lat_mem_rd microbenchmark.'
+        },
+        {
+            id: 'execution_latency',
+            title: 'Execution Latency',
+            description: 'The execution latency view identifies lines with high execution latency. The lines are sorted by total execution latency, and are reported with average execution latency and total count.'
+        },
+        {
+            id: 'issue_latency',
+            title: 'Issue Latency',
+            description: 'The issue latency view identifies lines with high issue latency. The lines are sorted by total issue latency, and are reported with average issue latency and total count.'
+        },
+        {
+            id: 'translation_latency',
+            title: 'MMU Translation Latency',
+            description: 'The translation latency view identifies lines with high translation latency. The lines are sorted by total translation latency, and are reported with average translation latency and total count.'
+        }
+    ];
+
+    const branchConfigs = [
+        {
+            id: 'branch',
+            title: 'Branch Misses',
+            description: 'The branch miss view identifies conditional and indirect branch instructions. The instructions are sorted by count, and are reported with the branch misprediction rate and count.'
+        }
+    ];
+
+    const buttonContainer = document.getElementById('button-container');
+    const tableContent = document.getElementById('table-content');
+
+    // Create Memory Operations group
+    const memoryGroup = document.createElement('div');
+    memoryGroup.className = 'button-group';
+    const memoryLabel = document.createElement('h3');
+    memoryLabel.textContent = 'Memory Operations';
+    memoryGroup.appendChild(memoryLabel);
+
+    memoryConfigs.forEach(config => {
+        const button = document.createElement('button');
+        button.textContent = config.title;
+        button.className = 'table-button';
+        button.addEventListener('click', (e) => {
+            document.querySelectorAll('.table-button').forEach(btn => 
+                btn.classList.remove('active'));
+            button.classList.add('active');
+            loadTable(config);
+        });
+        memoryGroup.appendChild(button);
+    });
+
+    // Create Branch Predictor group
+    const branchGroup = document.createElement('div');
+    branchGroup.className = 'button-group';
+    const branchLabel = document.createElement('h3');
+    branchLabel.textContent = 'Branch Predictor';
+    branchGroup.appendChild(branchLabel);
+
+    branchConfigs.forEach(config => {
+        const button = document.createElement('button');
+        button.textContent = config.title;
+        button.className = 'table-button';
+        button.addEventListener('click', (e) => {
+            document.querySelectorAll('.table-button').forEach(btn => 
+                btn.classList.remove('active'));
+            button.classList.add('active');
+            loadTable(config);
+        });
+        branchGroup.appendChild(button);
+    });
+
+    // Add groups to container
+    buttonContainer.appendChild(memoryGroup);
+    buttonContainer.appendChild(branchGroup);
+
+    // Function to load table content using iframe
+    function loadTable(config) {
+        const contentWrapper = `
+            <h2>${config.title}</h2>
+            ${config.description ? `<p class="table-description">${config.description}</p>` : ''}
+            <div class="table-container">
+                <iframe src="data/js/${config.id}.html" 
+                        frameborder="0" 
+                        style="width: 100%; height: 500px;"
+                        onload="this.height = this.contentWindow.document.documentElement.scrollHeight + 'px';">
+                </iframe>
+            </div>
+        `;
+        tableContent.innerHTML = contentWrapper;
+    }
+
+    // Load the first table by default and activate its button
+    const firstButton = buttonContainer.querySelector('.table-button');
+    if (firstButton) {
+        firstButton.classList.add('active');
+        loadTable(memoryConfigs[0]);
+    }
+});

--- a/src/html_files/index.css
+++ b/src/html_files/index.css
@@ -82,10 +82,54 @@ body {
   background-color: #ccc;
 }
 
-/* Style the tab content */
 .tabcontent {
   grid-row: 2;
   border: 1px solid #ccc;
   width: 100%;
   height: 100%;
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1em;
+    table-layout: auto;
+}
+th, td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+    min-width: 100px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+th {
+    background-color: #f2f2f2;
+    font-weight: bold;
+}
+tr:nth-child(even) {
+    background-color: #f9f9f9;
+}
+tr:hover {
+    background-color: #f5f5f5;
+}
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+}
+.toggle-button {
+    margin: 10px;
+    padding: 5px 10px;
+    cursor: pointer;
+}
+
+.assembly-column, .source-column {
+    min-width: 300px;
+}
+
+.table-description {
+    margin: 1em 0;
+    line-height: 1.5;
+    font-size: 0.9em;
 }

--- a/src/html_files/index.html
+++ b/src/html_files/index.html
@@ -15,6 +15,7 @@
 			<button class="tablinks" name="cpu_utilization">CPU Utilization</button>
 			<button class="tablinks" name="flamegraphs">Flamegraphs</button>
 			<button class="tablinks" name="top_functions">Top Functions</button>
+			<button class="tablinks" name="hotline">Hotline</button>
 			<button class="tablinks" name="processes">Processes</button>
 			<button class="tablinks" name="perfstat">PMU Stats</button>
 			<button class="tablinks" name="meminfo">Meminfo</button>
@@ -119,7 +120,23 @@
 					<div id="cpus-configure"></div>
 				</div>
 			</div>
+			<div id="hotline" class="tabcontent">
+				<div id="hotline-runs" class="extra">
+					<h1>Hotline</h1>
+					
+					<div id="button-container">
+						<!-- The button groups will be dynamically inserted here by JavaScript -->
+					</div>
+
+					<div id="table-content">
+						<!-- The table content will be loaded here -->
+					</div>
+				</div>
+			</div>
+
+
 		</div>
+		<script type="text/javascript" src="data/js/hotline.js"></script>
 		<script type="text/javascript" src="data/js/runs.js"></script>
 		<script type="text/javascript" src="data/js/system_info.js"></script>
 		<script type="text/javascript" src="data/js/sysctl.js"></script>
@@ -139,6 +156,7 @@
 		<script type="text/javascript" src="data/js/java_profile.js"></script>
 		<script type="text/javascript" src="data/js/analytics.js"></script>
 		<script type="text/javascript" src="js/utils.js"></script>
+		<script type="text/javascript" src="js/hotline_profile.js"></script>
 		<script type="text/javascript" src="js/plotly.js" charset="utf-8"></script>
 		<script type="text/javascript" src="js/system_info.js"></script>
 		<script type="text/javascript" src="js/cpu_utilization.js"></script>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,6 +564,8 @@ pub struct InitParams {
     pub tmp_dir: PathBuf,
     pub runlog: PathBuf,
     pub perf_frequency: u32,
+    pub hotline_frequency: u32,
+    pub num_to_report: u32,
 }
 
 impl InitParams {
@@ -604,6 +606,8 @@ impl InitParams {
             tmp_dir: PathBuf::from(APERF_TMP),
             runlog: PathBuf::new(),
             perf_frequency: 99,
+            hotline_frequency: 1000,
+            num_to_report: 5000,
         }
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -34,6 +34,14 @@ pub struct Record {
     /// Custom PMU config file to use.
     #[clap(long, value_parser)]
     pub pmu_config: Option<String>,
+
+    /// SPE sampling frequency, defaulted to 1kHz on Grv4.
+    #[clap(long, value_parser, default_value_t = 1000)]
+    pub hotline_frequency: u32,
+
+    /// Maximum number of report entries to process for Hotline tables
+    #[clap(long, value_parser, default_value_t = 5000)]
+    pub num_to_report: u32,
 }
 
 fn prepare_data_collectors() -> Result<()> {
@@ -55,6 +63,8 @@ fn collect_static_data() -> Result<()> {
 }
 
 pub fn record(record: &Record, tmp_dir: &Path, runlog: &Path) -> Result<()> {
+    println!("runlog: {:?}", runlog);
+
     let mut run_name = String::new();
     if record.period == 0 {
         error!("Collection period cannot be 0.");
@@ -82,6 +92,9 @@ pub fn record(record: &Record, tmp_dir: &Path, runlog: &Path) -> Result<()> {
     if let Some(p) = &record.pmu_config {
         params.pmu_config = Some(PathBuf::from(p));
     }
+
+    params.hotline_frequency = record.hotline_frequency;
+    params.num_to_report = record.num_to_report;
 
     match &record.profile_java {
         Some(j) => {


### PR DESCRIPTION
Hotline utilizes the ARM Statistical Profiling Extension (SPE) to generate data views. Hotline reveals code hotspots by read latency (issue, execution, and translation), cache locality (completion node), and branch predictions misses.

Hotline collects SPE statistics in-memory by code address as part of `aperf record`, then shows the user hot lines of code as a part of `aperf report`. It has a CPU overhead of 2% or less.

Hotline requires the ARM SPE driver, which is only supported on Grv 2/3/4 metal instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
