### PR TITLE
Create repo-sync.yml to enable repo-sync between repos

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,125 @@
+
+name: Repo Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/30 * * * *" # once every 30 minutes
+
+jobs:
+  repo-sync:
+    name: Repo Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: repo-sync/github-sync@v2
+        name: Sync repo to branch
+        with:
+          source_repo: ${{ secrets.SOURCE_REPO }}
+          source_branch: main
+          destination_branch: repo-sync
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          sync_tags: "true"
+      - name: Ship pull request
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.WORKFLOW_TOKEN }}
+          result-encoding: string
+          script: |
+            const { owner, repo } = context.repo
+            const head = 'repo-sync'
+            const base = 'main'
+
+            async function closePullRequest(prNumber) {
+              console.log('Closing pull request', prNumber)
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: prNumber,
+                state: 'closed'
+              })
+              // Error loud here, so no try/catch
+              console.log('Closed pull request', prNumber)
+            }
+
+            console.log('Closing any existing pull requests')
+            const { data: existingPulls } = await github.rest.pulls.list({ owner, repo, head, base })
+            if (existingPulls.length) {
+              console.log('Found existing pull requests', existingPulls.map(pull => pull.number))
+              for (const pull of existingPulls) {
+                await closePullRequest(pull.number)
+              }
+              console.log('Closed existing pull requests')
+            }
+
+            try {
+              const { data } = await github.rest.repos.compareCommits({
+                owner,
+                repo,
+                head,
+                base,
+              })
+              const { files } = data
+              console.log(`File changes between ${head} and ${base}:`, files)
+              if (!files.length) {
+                console.log('No files changed, bailing')
+                return
+              }
+            } catch (err) {
+              console.error(`Unable to compute the files difference between ${head} and ${base}: `, err.message)
+              throw err
+            }
+
+            console.log('Creating a new pull request')
+            const body = 'This is an automated pull request to sync changes between the public and private repos. Our bot will merge this pull request automatically. To preserve continuity across repos, do not manually merge the pull request.'
+            let pull, pull_number
+            try {
+              const response = await github.rest.pulls.create({
+                owner,
+                repo,
+                head,
+                base,
+                title: 'Repo sync',
+                body,
+              })
+              pull = response.data
+              pull_number = pull.number
+              console.log('Created pull request successfully', pull.html_url)
+            } catch (err) {
+              // Don't error/alert if there's no commits to sync
+              // Don't throw if > 100 pulls with same head_sha issue
+              if (err.message?.includes('No commits') || err.message?.includes('same head_sha')) {
+                console.log(err.message)
+                return
+              }
+              throw err
+            }
+
+            console.log('Counting files changed')
+            const { data: prFiles } = await github.rest.pulls.listFiles({ owner, repo, pull_number })
+            if (prFiles.length) {
+              console.log(prFiles.length, 'files have changed')
+            } else {
+              console.log('No files changed, closing')
+              await closePullRequest(pull_number)
+              return
+            }
+
+            console.log('Checking for merge conflicts')
+            if (pull.mergeable_state === 'dirty') {
+              console.log('Pull request has a conflict', pull.html_url)
+              await closePullRequest(pull_number)
+              throw new Error('Pull request has a conflict, please resolve manually')
+            }
+            console.log('No detected merge conflicts')
+
+            console.log('Merging the pull request')
+            // Admin merge pull request to avoid squash
+            await github.rest.pulls.merge({
+              owner,
+              repo,
+              pull_number,
+              merge_method: 'merge',
+            })
+            // Error loud here, so no try/catch
+            console.log('Merged the pull request successfully')


### PR DESCRIPTION
*Issue #, if available:*
This change aims to use the [repo-sync](https://github.com/repo-sync/repo-sync) tool to keep the two repos in sync

*Description of changes:*

Following the instructions listed in the [repo-sync's official guide](https://github.com/repo-sync/repo-sync/blob/master/README.md), as well as [the actual implementation in the GitHub Docs repo](https://github.com/github/docs/blob/main/.github/workflows/repo-sync.yml), to create the `repo-sync.yml` file that defines the sync workflow:
* It runs once per day (we can change it to a higher frequency if needed)
* When new changes had been made to a repo before a run, it publishes and merges a PR

The commit history, including each commit's SHA, of the two repos will be kept exactly the same.

The secrets used by the workflow will be created in the next step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
