### PR TITLE
Remove the logic of closing existing PRs in the repo-sync workflow

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -42,16 +42,6 @@ jobs:
               console.log('Closed pull request', prNumber)
             }
 
-            console.log('Closing any existing pull requests')
-            const { data: existingPulls } = await github.rest.pulls.list({ owner, repo, head, base })
-            if (existingPulls.length) {
-              console.log('Found existing pull requests', existingPulls.map(pull => pull.number))
-              for (const pull of existingPulls) {
-                await closePullRequest(pull.number)
-              }
-              console.log('Closed existing pull requests')
-            }
-
             try {
               const { data } = await github.rest.repos.compareCommits({
                 owner,


### PR DESCRIPTION
*Issue #, if available:*

The logic of closing all existing PRs prevents contributing directly to main through a PR.

*Description of changes:*

Remove the logic of closing all existing PRs in the repo-sync workflow. It will only compare the source and target branches, raise a new PR, and merges it in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
