### PR TITLE
Add --dont-collect and --collect-only flags to customize which data to collect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /node_modules
 .idea
+./pmu_config.json

--- a/src/bin/aperf.rs
+++ b/src/bin/aperf.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use aperf::pmu::{custom_pmu, CustomPMU};
-use aperf::record::{record, Record};
+use aperf::record::{record, Record, RECORD_DATA_RECOMMENDATION};
 use aperf::report::{report, Report};
 use aperf::{PDError, APERF_RUNLOG, APERF_TMP};
 use clap::{Parser, Subcommand};
@@ -25,17 +25,18 @@ struct Cli {
     command: Commands,
 
     /// Show debug messages. Use -vv for more verbose messages.
-    #[clap(short, long, global = true, action = clap::ArgAction::Count)]
+    #[clap(help_heading = "Basic Options", short, long, global = true, action = clap::ArgAction::Count)]
     verbose: u8,
 
     /// Temporary directory for intermediate files.
-    #[clap(short, long, value_parser, default_value_t = APERF_TMP.to_string(), global = true)]
+    #[clap(help_heading = "Basic Options", short, long, value_parser, default_value_t = APERF_TMP.to_string(), global = true)]
     tmp_dir: String,
 }
 
 #[derive(Subcommand)]
 enum Commands {
     /// Collect performance data.
+    #[command(after_help = RECORD_DATA_RECOMMENDATION.to_ascii_uppercase())]
     Record(Record),
 
     /// Generate an HTML report based on the data collected.

--- a/src/data/perf_profile.rs
+++ b/src/data/perf_profile.rs
@@ -148,8 +148,6 @@ impl GetData for PerfProfile {
                 .split('\n')
                 .map(|x| x.to_string())
                 .collect();
-        } else {
-            profile.data = vec!["No data collected".to_string()];
         }
 
         let processed_data = vec![ProcessedData::PerfProfile(profile)];

--- a/src/html_files/aperf_runlog.ts
+++ b/src/html_files/aperf_runlog.ts
@@ -1,16 +1,13 @@
 let got_aperf_runlog_data = false;
 
 function getRunlogs(run, container_id, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     var div = document.createElement('div');
     div.id = `aperfrunlog-${run}-container`;
     addElemToNode(container_id, div);
-    if (run_data == "No data collected") {
-        var text_value = document.createElement('pre');
-        text_value.innerHTML = run_data;
-        addElemToNode(div.id, text_value);
-        return;
-    }
-    let data = JSON.parse(run_data);
+
+    let data = JSON.parse(run_data['values']);
     data[0].data.forEach(function (value, index, arr) {
         var text_value = document.createElement('pre');
         text_value.style.whiteSpace = "pre-wrap";
@@ -28,7 +25,7 @@ function aperfRunlog() {
         let elem_id = `${run_name}-aperfrunlog-per-data`;
         let this_run_data = aperf_runlog_raw_data['runs'][i];
         setTimeout(() => {
-            getRunlogs(run_name, elem_id, this_run_data['key_values']['values']);
+            getRunlogs(run_name, elem_id, this_run_data['key_values']);
         })
     }
     got_aperf_runlog_data = true;

--- a/src/html_files/aperf_stats.ts
+++ b/src/html_files/aperf_stats.ts
@@ -50,16 +50,13 @@ function getAperfEntry(elem, key, run_data) {
 }
 
 function getAperfEntries(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];
         var elem = document.createElement('div');
         elem.id = `aperfstat-${run}-${value}`;
         elem.style.float = "none";
-        if (keys.length == 0) {
-            elem.innerHTML = "No data collected";
-            addElemToNode(container_id, elem);
-            return;
-        }
         addElemToNode(container_id, elem);
         emptyOrCallback(keys, false, getAperfEntry, elem, value, run_data);
     }

--- a/src/html_files/configure.ts
+++ b/src/html_files/configure.ts
@@ -24,13 +24,19 @@ function formGlobalConfig() {
         let run_name = this_run_data['name'];
         var config = new RunConfig();
 
-        /* Elemet 0 is aggregate. Don't use that. */
-        let key = this_run_data['keys'][1];
-        config.cpu_count = JSON.parse(this_run_data['key_values'][key]).length;
-        config.cpu_list = new Array<string>();
-        for (let i = 0; i < config.cpu_count; i++) {
-            config.cpu_list.push(i.toString());
+        if (this_run_data['keys'].length > 1) {
+            /* Elemet 0 is aggregate. Don't use that. */
+            let key = this_run_data['keys'][1];
+            config.cpu_count = JSON.parse(this_run_data['key_values'][key]).length;
+            config.cpu_list = new Array<string>();
+            for (let i = 0; i < config.cpu_count; i++) {
+                config.cpu_list.push(i.toString());
+            }
+        } else {
+            config.cpu_count = 0;
+            config.cpu_list = new Array<string>();
         }
+
         config.all_selected = true;
         run_config.set(run_name, config);
     }

--- a/src/html_files/cpu_utilization.ts
+++ b/src/html_files/cpu_utilization.ts
@@ -192,6 +192,9 @@ function cpuUtilization() {
         util_cpu_list.set(run_name, getCPUList(run_name));
         let elem_id = `${run_name}-cpuutilization-per-data`;
         let this_run_data = cpu_utilization_raw_data['runs'][i];
+
+        if (handleNoData(elem_id, this_run_data['key_values'])) continue;
+
         getCpuUtilization(document.getElementById(elem_id), run_name, this_run_data['key_values']['aggregate']);
         getUtilizationTypes(run_name, elem_id, this_run_data['keys'], this_run_data['key_values']);
     }

--- a/src/html_files/diskstats.ts
+++ b/src/html_files/diskstats.ts
@@ -49,6 +49,8 @@ function getStatValues(elem, key, run_data) {
 }
 
 function getStatKeys(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+    
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];
         var elem = document.createElement('div');

--- a/src/html_files/flamegraphs.ts
+++ b/src/html_files/flamegraphs.ts
@@ -1,14 +1,9 @@
 let got_flamegraphs_data: boolean|string = "none";
 
 function getJavaFlamegraphInfo(run, container_id, run_data){
-    let data;
-    // TODO: temporary solution for when data is not collected - implement
-    //      a cleaner unified solution for all type of uncollected data
-    try {
-        data = JSON.parse(run_data['values']);
-    } catch (_) {
-        data = []
-    }
+    if (handleNoData(container_id, run_data)) return;
+
+    let data = JSON.parse(run_data['values']);
 
     let sorted = Object.keys(data).sort(function(x,y){
         return data[y][1] - data[x][1];
@@ -35,16 +30,10 @@ function getJavaFlamegraphInfo(run, container_id, run_data){
 }
 
 function getFlamegraphInfo(run, container_id, run_data) {
-    // TODO: temporary solution for when data is not collected - implement
-    //      a cleaner unified solution for all type of uncollected data
-    if (run_data['values'] == 'No data collected') {
-        var h3 = document.createElement('h3');
-        h3.innerText = `No data collected.`;
-        addElemToNode(container_id, h3);
-        return;
-    }
+    if (handleNoData(container_id, run_data)) return;
+
     var div = document.createElement('iframe');
-    div.src = `data/js/${run}-flamegraph.svg`;
+    div.src = run_data['values'];
     div.style.width = `100%`;
     div.style.height = `100vh`;
     addElemToNode(container_id, div);

--- a/src/html_files/hotline.ts
+++ b/src/html_files/hotline.ts
@@ -142,7 +142,7 @@ function loadTables(config) {
     console.warn("No data collected");
   } else {
     hotline_raw_data.runs.forEach((run, index) => {
-      if (run.key_values.values === "No data collected") {
+      if (Object.keys(run.key_values).length == 0) {
         contentWrapper += no_data_div;
       } else {
         let values;

--- a/src/html_files/interrupts.ts
+++ b/src/html_files/interrupts.ts
@@ -47,6 +47,8 @@ function getLine(run, elem, key, run_data) {
 }
 
 function getLines(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     var data = keys;
     data.forEach(function (value, index, arr) {
         var elem = document.createElement('div');

--- a/src/html_files/kernel_config.ts
+++ b/src/html_files/kernel_config.ts
@@ -116,9 +116,22 @@ function kernelConfig(diff: boolean) {
         return;
     }
     current_kernel_diff_status = diff;
+    clear_and_create('kernel');
+
+    let no_data_run_names = new Set();
+    for (let run of kernel_config_raw_data['runs']) {
+        let run_name = run["name"];
+        let elem_id = `${run_name}-kernel-per-data`;
+        if (handleNoData(elem_id, run["key_values"])) {
+            no_data_run_names.add(run_name);
+        }
+    }
+
     var data = runs_raw;
     if (!got_kernel_config_data) {
         data.forEach(function (value, index, arr) {
+            if (no_data_run_names.has(value)) return;
+
             let this_run_data;
             for (let i = 0; i < kernel_config_raw_data['runs'].length; i++) {
                 if (kernel_config_raw_data['runs'][i]['name'] == value) {
@@ -129,8 +142,10 @@ function kernelConfig(diff: boolean) {
         })
         split_keys(kernel_config_runs, kernel_config_common_keys);
     }
-    clear_and_create('kernel');
+
     data.forEach(function (value, index, arr) {
+        if (no_data_run_names.has(value)) return;
+
         let elem_id = `${value}-kernel-per-data`;
         if (current_kernel_diff_status) {
             kernelConfigDiff(value, elem_id);

--- a/src/html_files/meminfo.ts
+++ b/src/html_files/meminfo.ts
@@ -114,6 +114,8 @@ function getMeminfo(elem, key, run_data) {
 }
 
 function getMeminfoKeys(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];
         var elem = document.createElement('div');

--- a/src/html_files/netstat.ts
+++ b/src/html_files/netstat.ts
@@ -8,6 +8,8 @@ let netstat_rules = {
 }
 
 function getNetstatEntries(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];
         var elem = document.createElement('div');

--- a/src/html_files/perf_profile.ts
+++ b/src/html_files/perf_profile.ts
@@ -1,7 +1,9 @@
 let got_top_functions_data = false;
 
 function getTopFunctionsInfo(run, container_id, run_data) {
-    let data = JSON.parse(run_data);
+    if (handleNoData(container_id, run_data)) return;
+
+    let data = JSON.parse(run_data['values']);
     var div = document.createElement('div');
     div.id = `${run}-top-functions-container`;
     addElemToNode(container_id, div);
@@ -24,15 +26,7 @@ function topFunctions() {
         let elem_id = `${run_name}-topfunctions-per-data`;
         let this_run_data = perf_profile_raw_data['runs'][i];
         setTimeout(() => {
-            try {
-                getTopFunctionsInfo(run_name, elem_id, this_run_data['key_values']['values']);
-            } catch (_) {
-                // TODO: temporary temporary solution for when data is not collected - implement
-                //      cleaner unified solution for all type of uncollected data
-                let no_data_div = document.createElement('div');
-                no_data_div.innerText = "No data collected.";
-                addElemToNode(elem_id, no_data_div);
-            }
+            getTopFunctionsInfo(run_name, elem_id, this_run_data['key_values']);
         }, 0);
     }
     got_top_functions_data = true;

--- a/src/html_files/perf_stat.ts
+++ b/src/html_files/perf_stat.ts
@@ -72,6 +72,8 @@ let perf_stat_rules = {
     ]
 }
 function getEvents(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     if (keys.length == 0) {
         var no_data_div = document.createElement('div');
         no_data_div.id = `perfstat-${run}-nodata`;

--- a/src/html_files/processes.ts
+++ b/src/html_files/processes.ts
@@ -1,13 +1,8 @@
 let got_process_data = false;
 
 function getProcesses(run, container_id, run_data) {
-    if (run_data.values == "No data collected") {
-        var no_data_div = document.createElement('div');
-        no_data_div.id = `processes-${run}-no-data`;
-        no_data_div.innerHTML = "No data collected";
-        addElemToNode(container_id, no_data_div);
-        return;
-    }
+    if (handleNoData(container_id, run_data)) return;
+
     var data = JSON.parse(run_data.values);
     data.end_entries.forEach(function (value, index, arr) {
         let process_datas = [];

--- a/src/html_files/sysctl.ts
+++ b/src/html_files/sysctl.ts
@@ -69,9 +69,22 @@ function sysctl(diff: boolean) {
         return;
     }
     current_sysctl_diff_status = diff;
+    clear_and_create('sysctl');
+
+    let no_data_run_names = new Set();
+    for (let run of sysctl_raw_data['runs']) {
+        let run_name = run["name"];
+        let elem_id = `${run_name}-sysctl-per-data`;
+        if (handleNoData(elem_id, run["key_values"])) {
+            no_data_run_names.add(run_name);
+        }
+    }
+
     var data = runs_raw;
     if (!got_sysctl_data) {
         data.forEach(function (value, index, arr) {
+            if (no_data_run_names.has(value)) return;
+
             let this_run_data;
             for (let i = 0; i < sysctl_raw_data['runs'].length; i++) {
                 if (sysctl_raw_data['runs'][i]['name'] == value) {
@@ -83,8 +96,9 @@ function sysctl(diff: boolean) {
         split_keys(sysctl_runs, sysctl_common_keys);
     }
 
-    clear_and_create('sysctl');
     data.forEach(function (value, index, arr) {
+        if (no_data_run_names.has(value)) return;
+
         if (current_sysctl_diff_status) {
             sysctlDiff(value, `${value}-sysctl-per-data`);
         } else {

--- a/src/html_files/systeminfo.ts
+++ b/src/html_files/systeminfo.ts
@@ -46,7 +46,9 @@ let systeminfo_rules = {
 }
 
 function getSystemInfo(run, container_id, run_data) {
-    var data = JSON.parse(run_data);
+    if (handleNoData(container_id, run_data)) return;
+
+    var data = JSON.parse(run_data['values']);
     data.forEach(function (value, index, arr) {
         var div = document.createElement('div');
         div.id = `${run}-${value.name}-container`;
@@ -164,7 +166,7 @@ function sutconfig() {
         let elem_id = `${run_name}-systeminfo-per-data`;
         let this_run_data = systeminfo_raw_data['runs'][i];
         setTimeout(() => {
-            getSystemInfo(run_name, elem_id, this_run_data['key_values']['values']);
+            getSystemInfo(run_name, elem_id, this_run_data['key_values']);
         }, 0);
     }
 }

--- a/src/html_files/utils.ts
+++ b/src/html_files/utils.ts
@@ -68,6 +68,16 @@ function form_graph_limits(data) {
     }
 }
 
+function handleNoData(container_id, run_data) {
+    if (Object.keys(run_data).length === 0) {
+        let no_data_div = document.createElement("div");
+        no_data_div.innerText = "No data collected";
+        addElemToNode(container_id, no_data_div);
+        return true;
+    }
+    return false;
+}
+
 function canHide(hide, keys, key) {
     let limits = key_limits.get(key);
     if (limits.low == 0 && limits.high == 0 && hide) {
@@ -75,6 +85,7 @@ function canHide(hide, keys, key) {
     }
     return false;
 }
+
 function emptyOrCallback(keys, hide, callback, elem, key, run_data, run="") {
     if (canHide(hide, keys, key)) {
         return;
@@ -89,6 +100,7 @@ function emptyOrCallback(keys, hide, callback, elem, key, run_data, run="") {
         }, 0);
     }
 }
+
 function emptyGraph(elem, key) {
     var layout = {
         title: `${key} (N/A)`,

--- a/src/html_files/vmstat.ts
+++ b/src/html_files/vmstat.ts
@@ -8,6 +8,8 @@ let vmstat_rules = {
 }
 
 function getEntries(run, container_id, keys, run_data) {
+    if (handleNoData(container_id, run_data)) return;
+
     for (let i = 0; i < all_run_keys.length; i++) {
         let value = all_run_keys[i];
         var elem = document.createElement('div');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ pub enum PDError {
     #[error("Error getting Netstat value for {}", .0)]
     VisualizerNetstatValueGetError(String),
 
+    #[error("{} data is not available for run {}", .0, .1)]
+    DataUnavailableError(String, String),
+
     #[error("Error getting Line Name Error")]
     CollectorLineNameError,
 
@@ -417,7 +420,6 @@ impl VisualizationData {
                 visualizer.init_visualizer(dir.clone(), dir_name.clone(), tmp_dir, fin_dir)
             {
                 debug!("{:#?}", e);
-                visualizer.data_not_available(dir_name.clone())?;
                 error_count += 1;
             }
         }
@@ -482,6 +484,17 @@ impl VisualizationData {
 
     pub fn get_run_names(&mut self) -> Result<String> {
         Ok(serde_json::to_string(&self.run_names)?)
+    }
+
+    pub fn is_data_available(&self, run_name: &String, visualizer_name: &str) -> bool {
+        self.visualizers
+            .get(visualizer_name)
+            .is_some_and(|visualizer| {
+                visualizer
+                    .data_available
+                    .get(run_name)
+                    .is_some_and(|&value| value)
+            })
     }
 
     pub fn get_data(

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -15,11 +15,11 @@ use std::path::PathBuf;
 #[derive(Args, Debug)]
 pub struct CustomPMU {
     /// Name of the file for the custom PMU configuration.
-    #[clap(short, long, value_parser)]
+    #[clap(help_heading = "PMU Options", short, long, value_parser)]
     pub pmu_file: Option<String>,
 
     /// Verify the supplied pmu file.
-    #[clap(long, value_parser)]
+    #[clap(help_heading = "PMU Options", long, value_parser)]
     pub verify: bool,
 }
 


### PR DESCRIPTION

## Issue

Mirroring internal CR 212108965

## Description

* added the `--dont-collect` and `--collect-only` flags to allow users to select what performance data to select.
* reformatted the help menu by setting `help_heading` for each flag, which groups the flags into sections in the help menu
* remodeled the cases when data is not available:
  * an error is thrown when invoking `get_data` method on an unavailable data
  * upstream is expected to check if data is available before calling `get_data`
* added Typescript function `handleNoData()` that inserts the "No data collected" message into the report, if the run data is empty
* Revamped the help menu and README (for the new README, see https://github.com/CongkaiTan/aperf/blob/53d9684d58df0b844b236be89e6ebfb0e944e9b6/README.md)

Below is the new `aperf record -h` output:

```
dev-dsk-congkai-2a-8e335c45 % aperf record -h
Collect performance data

Usage: aperf record [OPTIONS]

Options:
  -h, --help     Print help
  -V, --version  Print version

Basic Options:
  -r, --run-name <RUN_NAME>  Name of the run
  -i, --interval <INTERVAL>  Interval (in seconds) at which performance data is to be collected [default: 1]
  -p, --period <PERIOD>      Time (in seconds) for which the performance data is to be collected [default: 10]
  -v, --verbose...           Show debug messages. Use -vv for more verbose messages
  -t, --tmp-dir <TMP_DIR>    Temporary directory for intermediate files [default: /tmp]

Data Selection:
      --dont-collect <Data Name>,<Data Name>,...
          The list of performance data to skip collection. Cannot be used with --collect_only [possible values: cpu_utilization, vmstat, disk_stats, system_info, kernel_config, interrupts, sysctl, perf_stat, processes, meminfo, netstat]
      --collect-only <Data Name>,<Data Name>,...
          The list of performance data to be collected - the others will not be collected. Cannot be used with --dont_collect [possible values: cpu_utilization, vmstat, disk_stats, system_info, kernel_config, interrupts, sysctl, perf_stat, processes, meminfo, netstat]

Perf Profiling:
      --profile                          Gather profiling data using 'perf' binary
  -F, --perf-frequency <PERF_FREQUENCY>  Frequency for perf profiling (Hz) [default: 99]

Java Profiling:
      --profile-java [<PID/Name>,<PID/Name>,...,<PID/Name>]
          Profile JVMs using async-profiler. Specify args using comma separated values. Profiles all JVMs if no args are provided

PMU Options:
      --pmu-config <PMU_CONFIG>  Custom PMU config file to use

WE RECOMMEND TO ALWAYS COLLECT AS MUCH DATA AS POSSIBLE FOR PERFORMANCE DEBUGGING, UNLESS YOU ARE SURE SOME DATA CAN BE EXCLUDED.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
