### PR TITLE
fix silent failure in eks-aperf.sh

### DIFF
--- a/eks-aperf.sh
+++ b/eks-aperf.sh
@@ -174,7 +174,6 @@ fi
 
 # Show resource usage for pods on this node
 echo -e "${BOLD}Resource usage for pods on ${NODE_NAME}:${NC}"
-rm  /tmp/allpods.out 2> /dev/null || true
 kubectl top pods --all-namespaces > /tmp/allpods.out  && \
 head -n 1 /tmp/allpods.out  &&  \
 grep "$(kubectl get pods --all-namespaces --field-selector spec.nodeName=${NODE_NAME} -o jsonpath='{range .items[*]}{.metadata.name}{" "}{end}' | sed 's/[[:space:]]*$//' | sed 's/[[:space:]]/\\|/g')" /tmp/allpods.out --color=never


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
fixing an issue where if /tmp/allpods.out doesn't exist the script will fail silently

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
