### PR TITLE
Fix crash when previous disk stat value is missing

### DIFF
--- a/src/data/diskstats.rs
+++ b/src/data/diskstats.rs
@@ -276,6 +276,10 @@ fn get_values(values: Vec<Diskstats>, key: String, metrics: &mut DataMetrics) ->
             };
             metadata.update_limits(GraphLimitType::F64(stat_value));
             metric.insert_value(stat_value);
+
+            if !ev.contains_key(&disk.name) {
+                ev.insert(disk.name.clone(), DiskValues::new(disk.name.clone()));
+            }
             let dvs = ev.get_mut(&disk.name).unwrap();
             dvs.values.push(dv);
         }


### PR DESCRIPTION
*Description of changes:*

Fix crash in disk stat calculation when no previous value exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
