### PR TITLE
chore: Scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   repo-sync:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use minimal GitHub Token permissions. The workflows uses a PAT to perform the mutating operations, so it's safe to scope down the built-in GitHub token to contents:read only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
