### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "*/30 * * * *" # once every 30 minutes
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   repo-sync:
     name: Repo Sync


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.