### PR TITLE
Remove PID from name string of Java Graph to fix bug with comparison reports not aligning

### DIFF
--- a/src/data/java_profile.rs
+++ b/src/data/java_profile.rs
@@ -349,9 +349,8 @@ impl ProcessData for JavaProfile {
                     &params.report_dir.join(relative_path.clone()),
                 ) {
                     let graph_name = format!(
-                        "JVM: {}, PID: {} ({})",
+                        "JVM: {}, ({})",
                         process_names.first().map_or("unknown", |s| s.as_str()),
-                        process,
                         metric
                     );
                     graph_group.graphs.insert(


### PR DESCRIPTION
Change graph name to "JVM: {process_name}, ({metric}" from "JVM: {process_name}, {PID} ({metric})" to fix a bug with comparison reports not lining up Java flamegraphs because PIDs will not be identical between reports run on different nodes, after a service reboot.  Now reports line up as expected with this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
