### PR TITLE
Fix incorrect macos dir name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create MacOS artifacts
         run: |
           name=aperf-${{ github.ref_name }}-macos
-          tar -zcvf "$name".tar.gz -C macos-release-artifact aperf
+          tar -zcvf "$name".tar.gz -C macos-release-artifacts aperf
       - name: Create Windows artifacts
         run: |
           name=aperf-${{ github.ref_name }}-windows


### PR DESCRIPTION
## Description

Use the correct dir name for downloaded macos binaries


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
