### PR TITLE
Include kubectl-aperf script in release artifacts for Krew distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,7 @@ jobs:
         run: |
           ldd target/$(arch)-unknown-linux-musl/release/aperf 2>&1 | grep -E "not a dynamic executable|statically linked"
       - name: Archive release artifacts
-        run: |
-          mkdir -p release-artifacts
-          cp target/$(arch)-unknown-linux-musl/release/aperf release-artifacts/
-          cp kubectl-aperf release-artifacts/
-          tar -zcvf artifacts.tar.gz -C release-artifacts .
+        run: tar -zcvf artifacts.tar.gz -C target/$(arch)-unknown-linux-musl/release aperf
       - name: Upload x86_64 release artifacts
         uses: actions/upload-artifact@v4
         if: ${{ matrix.platform == 'X86' }}

--- a/.github/workflows/cross-platform-ci.yml
+++ b/.github/workflows/cross-platform-ci.yml
@@ -42,9 +42,7 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         with:
           name: macos-release-artifacts
-          path: |
-            target/release/aperf
-            kubectl-aperf
+          path: target/release/aperf
       - name: Upload Windows release artifacts
         uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Modified CI workflows to include the `kubectl-aperf` script in release artifacts alongside the `aperf` binary. This will enable distribution via Krew (kubectl plugin manager) by ensuring both files are available in release tarballs for all platforms (Linux x86_64, aarch64, and macOS).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.