### PR TITLE
fix: aperf pod isn't working with Karpenter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           mkdir "$name"
           cp kubectl-aperf "$name/"
           chmod +x "$name/kubectl-aperf"
+          cp LICENSE "$name/"
           tar -zcvf "$name".tar.gz "$name"
 
       # Upload Krew tarball

--- a/docs/README-EKS.md
+++ b/docs/README-EKS.md
@@ -60,8 +60,8 @@ kubectl aperf \
 - `--aperf_image`: ECR image URI (optional, default: `public.ecr.aws/aperf/aperf:latest`)
 - `--aperf_options`: APerf command options (optional, default: ``)
 - `--namespace`: Kubernetes namespace (optional, default: `default`)
-- `--cpu-request`: CPU request for the pod (optional, default: `1.0`)
-- `--memory-request`: Memory request for the pod (optional, default: `1Gi`)
+- `--cpu-request`: CPU request for the pod (optional, default: `10m`)
+- `--memory-request`: Memory request for the pod (optional, default: `64Mi`)
 - `--cpu-limit`: CPU limit for the pod (optional, default: `4.0`)
 - `--memory-limit`: Memory limit for the pod (optional, default: `4Gi`)
 
@@ -207,6 +207,18 @@ kubectl aperf \
   --aperf_image="${APERF_ECR_REPO}:latest" \
   --node="ip-10-0-120-104.us-west-2.compute.internal" 
 ```
+
+## Running on Karpenter-managed Clusters
+
+When using [Karpenter](https://karpenter.sh/) as your node autoscaler, be aware that Karpenter provisions nodes based on the aggregated resource requests of pending (unscheduled) pods. Since the aperf pod is created *after* the application pod is already running, Karpenter does not account for it when sizing the node. This means the node may not have enough allocatable capacity for the aperf pod's resource requests.
+
+The `kubectl-aperf` script performs a pre-flight capacity check before creating the pod. It compares the node's allocatable resources against the sum of all existing pod requests to verify there is room for the aperf pod. If the node is too constrained, the script will exit with an error and suggest running with zero requests:
+
+```bash
+kubectl aperf --node=<NODE_NAME> --cpu-request=0 --memory-request=0
+```
+
+Running with zero requests sets the pod's [QoS class](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) to `BestEffort`, making it the first candidate for eviction if the node runs low on resources during recording. The default non-zero requests (`10m` CPU, `64Mi` memory) place the pod in the `Burstable` QoS class, which is less likely to be evicted.
 
 ## Security Considerations
 

--- a/kubectl-aperf
+++ b/kubectl-aperf
@@ -15,8 +15,8 @@ APERF_IMAGE="public.ecr.aws/aperf/aperf:latest"
 REPORT_NAME="aperf_record"
 OPEN_BROWSER=true
 SHOW_HELP=false
-CPU_REQUEST="1.0"
-MEMORY_REQUEST="1Gi"
+CPU_REQUEST="0"
+MEMORY_REQUEST="0"
 CPU_LIMIT="4.0"
 MEMORY_LIMIT="4Gi"
 
@@ -147,8 +147,7 @@ metadata:
   labels:
     app: aperf
 spec:
-  nodeSelector:
-    kubernetes.io/hostname: "${NODE_NAME}"
+  nodeName: "${NODE_NAME}"
 ${TOLERATIONS}
   containers:
   - name: aperf-runner

--- a/kubectl-aperf
+++ b/kubectl-aperf
@@ -15,8 +15,8 @@ APERF_IMAGE="public.ecr.aws/aperf/aperf:latest"
 REPORT_NAME="aperf_record"
 OPEN_BROWSER=true
 SHOW_HELP=false
-CPU_REQUEST="0"
-MEMORY_REQUEST="0"
+CPU_REQUEST="10m"
+MEMORY_REQUEST="64Mi"
 CPU_LIMIT="4.0"
 MEMORY_LIMIT="4Gi"
 
@@ -244,6 +244,105 @@ if kubectl top pods --all-namespaces > /tmp/allpods.out 2>/dev/null; then
 else
   echo "  ${YELLOW}Note: kubectl top not available (metrics-server may not be installed)${NC}"
 fi
+
+# Pre-flight capacity check: verify the node can fit the aperf pod requests
+# This compares allocatable resources against the sum of all pod requests on the node.
+# The scheduler uses requests (not actual usage) to make scheduling decisions.
+
+# Convert a CPU value (e.g. "10m", "2", "1.5") to millicores
+cpu_to_milli() {
+  local val="$1"
+  if [[ "$val" =~ ^([0-9]+)m$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$val" =~ ^([0-9]+\.?[0-9]*)$ ]]; then
+    echo "$val * 1000" | bc | cut -d. -f1
+  else
+    echo "0"
+  fi
+}
+
+# Convert a memory value (e.g. "64Mi", "1Gi", "1024Ki", "1048576") to bytes
+mem_to_bytes() {
+  local val="$1"
+  if [[ "$val" =~ ^([0-9]+)Gi$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 1073741824 ))
+  elif [[ "$val" =~ ^([0-9]+)Mi$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 1048576 ))
+  elif [[ "$val" =~ ^([0-9]+)Ki$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 1024 ))
+  elif [[ "$val" =~ ^([0-9]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "0"
+  fi
+}
+
+check_node_capacity() {
+  local cpu_req="$1"
+  local mem_req="$2"
+
+  # Skip check if both requests are zero
+  if [[ "$cpu_req" == "0" && "$mem_req" == "0" ]]; then
+    return 0
+  fi
+
+  echo -e "${BOLD}Checking node allocatable capacity...${NC}"
+
+  local cpu_req_milli=$(cpu_to_milli "$cpu_req")
+  local mem_req_bytes=$(mem_to_bytes "$mem_req")
+
+  # Get node allocatable resources
+  local node_json
+  node_json=$(kubectl get node "${NODE_NAME}" -o json 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    echo -e "  ${YELLOW}Warning: Could not query node capacity. Proceeding anyway.${NC}"
+    return 0
+  fi
+
+  local alloc_cpu alloc_mem
+  alloc_cpu=$(echo "$node_json" | jq -r '.status.allocatable.cpu // "0"')
+  alloc_mem=$(echo "$node_json" | jq -r '.status.allocatable.memory // "0"')
+
+  local alloc_cpu_milli=$(cpu_to_milli "$alloc_cpu")
+  local alloc_mem_bytes=$(mem_to_bytes "$alloc_mem")
+
+  # Sum CPU and memory requests from all pods on this node
+  local total_cpu_milli=0
+  local total_mem_bytes=0
+  local pod_resources
+  pod_resources=$(kubectl get pods --all-namespaces --field-selector spec.nodeName="${NODE_NAME}" \
+    -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{" "}{.resources.requests.memory}{"\n"}{end}{end}' 2>/dev/null)
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local pcpu pmem
+    pcpu=$(echo "$line" | awk '{print $1}')
+    pmem=$(echo "$line" | awk '{print $2}')
+    total_cpu_milli=$(( total_cpu_milli + $(cpu_to_milli "$pcpu") ))
+    total_mem_bytes=$(( total_mem_bytes + $(mem_to_bytes "$pmem") ))
+  done <<< "$pod_resources"
+
+  local avail_cpu_milli=$(( alloc_cpu_milli - total_cpu_milli ))
+  local avail_mem_bytes=$(( alloc_mem_bytes - total_mem_bytes ))
+
+  echo -e "  Allocatable: ${alloc_cpu_milli}m CPU, $(( alloc_mem_bytes / 1048576 ))Mi memory"
+  echo -e "  Requested by existing pods: ${total_cpu_milli}m CPU, $(( total_mem_bytes / 1048576 ))Mi memory"
+  echo -e "  Available: ${avail_cpu_milli}m CPU, $(( avail_mem_bytes / 1048576 ))Mi memory"
+  echo -e "  APerf requests: ${cpu_req_milli}m CPU, $(( mem_req_bytes / 1048576 ))Mi memory"
+
+  if (( avail_cpu_milli < cpu_req_milli )) || (( avail_mem_bytes < mem_req_bytes )); then
+    echo -e "\n${RED}${BOLD}Error: Node '${NODE_NAME}' does not have enough allocatable capacity for the aperf pod.${NC}"
+    echo -e "${YELLOW}The node's remaining allocatable resources (based on pod requests) are insufficient.${NC}"
+    echo -e "${YELLOW}To run anyway with best-effort scheduling (pod may be evicted during recording), use:${NC}"
+    echo -e "${BLUE}  kubectl aperf --node=${NODE_NAME} --cpu-request=0 --memory-request=0${NC}"
+    exit 1
+  fi
+
+  echo -e "  ${GREEN}Node has sufficient allocatable capacity.${NC}"
+  return 0
+}
+
+check_node_capacity "$CPU_REQUEST" "$MEMORY_REQUEST"
 
 # Create APerf pod
 echo -e "\n${BOLD}Created pod configuration for node:${NC} ${NODE_NAME}${NC}"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* While testing with a fresh cluster using Karpenter the aperf pod couldn't be scheduled into the node due to using a restricted label in Karpenter and the fact of configuring resources for the pod didn't allow the kube scheduler to schedule the pods into the node as Karpenter provisioned exactly what the unscheduled pods needed. This PR uses a different node selector and sets to 0 the default pod requests (users can still configure specific resources if needed). I also added the LICENSE file to the kubectl release file as that's a requirement from the krew project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.